### PR TITLE
Accept script (closes #5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+## Branch naming
+
+Follow [Conventional Branch](https://conventional-branch.github.io/) — no initials prefix.
+
+Format: `<type>/<description>` where `<type>` is one of `feature`, `bugfix`, `hotfix`, `release`, `chore`. Lowercase, hyphens. No issue numbers in branch names — issue traceability lives in PR descriptions and commit messages.
+
+Examples:
+- `feature/accept-script`
+- `bugfix/symlink-clobber-detection`
+- `chore/update-readme`
+
+## Quickstart
+
+- Tests: `uv run pytest`
+- Runtime floor: Python 3.9 (matches stock macOS Xcode CLT). Each script begins with `from __future__ import annotations`.
+- No third-party runtime deps — stdlib + `git` only. `pytest` is dev-only.
+- Direct script invocation: `python3 scripts/install.py <args>` (no package context required).
+
+## Architecture
+
+Self-contained scripts (`scripts/install.py`, plus `accept.py`/`migrate.py`/`relink.py`/`doctor.py` as they land) sharing one `scripts/core.py`. Trivial ops (list, fetch, diff, remove) are inline `Bash` in `SKILL.md`. See PRD #1 for the full rationale.

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,11 +13,12 @@ Self-contained Python 3, stdlib only. Run directly:
 
 ```bash
 python3 ~/.claude/skills/sync-skills/scripts/install.py <name> <owner/repo> <path> [ref]
+python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
 ```
 
-Registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event.
+`install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`.
 
-More scripts (`accept`, `migrate`, `relink`, `doctor`) and the interactive `/sync-skills` review flow land in follow-up issues. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
+More scripts (`migrate`, `relink`, `doctor`) and the interactive `/sync-skills` review flow land in follow-up issues. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
 
 ## Inspecting state
 

--- a/scripts/accept.py
+++ b/scripts/accept.py
@@ -1,0 +1,24 @@
+"""Snap a skill's baseline/ to match its upstream/ (`baseline := upstream`).
+Append an `accept` audit event."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import core
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="accept.py")
+    parser.add_argument("name")
+    args = parser.parse_args(argv)
+
+    paths = core.paths_for(args.name)
+    core.copy_tree(paths.upstream, paths.baseline)
+    core.audit_append("accept", args.name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_accept.py
+++ b/tests/test_accept.py
@@ -1,0 +1,57 @@
+import accept
+import install
+
+
+def test_accept_snaps_baseline_to_upstream(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo("acme/w", "skills/w", {"SKILL.md": "v1\n"})
+    install.main(["w", repo_url, "skills/w"])
+
+    base = home / ".agents" / "sync-skills" / "w"
+    (base / "upstream" / "SKILL.md").write_text("v2\n")
+
+    rc = accept.main(["w"])
+    assert rc == 0
+    assert (base / "baseline" / "SKILL.md").read_text() == "v2\n"
+
+
+def test_accept_appends_audit_event(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo("acme/w", "skills/w", {"SKILL.md": "v1\n"})
+    install.main(["w", repo_url, "skills/w"])
+
+    accept.main(["w"])
+
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert len(history) == 2
+    assert "install" in history[0] and "w" in history[0]
+    assert "accept" in history[1] and "w" in history[1]
+
+
+def test_accept_handles_added_and_removed_files(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo(
+        "acme/w", "skills/w", {"SKILL.md": "v1\n", "old.py": "old = 1\n"}
+    )
+    install.main(["w", repo_url, "skills/w"])
+
+    base = home / ".agents" / "sync-skills" / "w"
+    (base / "upstream" / "old.py").unlink()
+    (base / "upstream" / "new.py").write_text("new = 1\n")
+
+    accept.main(["w"])
+
+    assert not (base / "baseline" / "old.py").exists()
+    assert (base / "baseline" / "new.py").read_text() == "new = 1\n"
+
+
+def test_accept_leaves_active_untouched(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo("acme/w", "skills/w", {"SKILL.md": "v1\n"})
+    install.main(["w", repo_url, "skills/w"])
+
+    base = home / ".agents" / "sync-skills" / "w"
+    (base / "active" / "SKILL.md").write_text("my custom v1\n")
+    (base / "active" / "my_helper.py").write_text("local = True\n")
+    (base / "upstream" / "SKILL.md").write_text("v2\n")
+
+    accept.main(["w"])
+
+    assert (base / "active" / "SKILL.md").read_text() == "my custom v1\n"
+    assert (base / "active" / "my_helper.py").read_text() == "local = True\n"


### PR DESCRIPTION
## Summary

- `scripts/accept.py <name>` snaps `baseline/` to `upstream/` and appends an `accept` audit event — the primitive behind cherry-pick / wholesale / skip in the upcoming `/sync-skills` flow.
- Documents `accept` in `SKILL.md` next to `install`.
- Adds the project `CLAUDE.md` (branch naming, quickstart, architecture pointer) as a separate first commit.

Closes #5.

## Test plan

- [x] `uv run pytest` — 7/7 passing (3 install + 4 accept)
- [x] Accept after fetch with no active changes → `baseline == upstream`
- [x] Accept with active customisations → `active/` untouched
- [x] Upstream adds/removes files → `baseline/` mirrors them
- [x] Audit log gets `accept <name>` line