### PR TITLE
Migrate script: port npx skills into sync-skills

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -14,11 +14,12 @@ Self-contained Python 3, stdlib only. Run directly:
 ```bash
 python3 ~/.claude/skills/sync-skills/scripts/install.py <name> <owner/repo> <path> [ref]
 python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
+python3 ~/.claude/skills/sync-skills/scripts/migrate.py [name]
 ```
 
-`install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`.
+`install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`. `migrate` ports a skill installed via `npx skills` (vercel-labs/skills) into sync-skills: copies `~/.agents/skills/<name>/` into all three trees, swings the symlink, registers it, and removes the entry from `~/.agents/.skill-lock.json`. With no name, migrates every entry in the lock file.
 
-More scripts (`migrate`, `relink`, `doctor`) and the interactive `/sync-skills` review flow land in follow-up issues. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
+More scripts (`relink`, `doctor`) and the interactive `/sync-skills` review flow land in follow-up issues. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
 
 ## Inspecting state
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,0 +1,93 @@
+"""Port skills installed via `npx skills` (vercel-labs/skills) into sync-skills.
+
+Reads ~/.agents/.skill-lock.json, copies ~/.agents/skills/<name>/ into all three
+trees, replaces the ~/.claude/skills/<name> symlink with one into active/,
+registers the entry, and removes it from the lock file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import core
+
+
+def _lock_path() -> Path:
+    return Path(os.environ["HOME"]) / ".agents" / ".skill-lock.json"
+
+
+def _npx_skill_dir(name: str) -> Path:
+    return Path(os.environ["HOME"]) / ".agents" / "skills" / name
+
+
+def _lock_load() -> dict:
+    p = _lock_path()
+    if not p.exists():
+        return {"version": 3, "skills": {}}
+    return json.loads(p.read_text())
+
+
+def _lock_save(data: dict) -> None:
+    _lock_path().write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _path_from_skillpath(skill_path: str) -> str:
+    if skill_path.endswith("/SKILL.md"):
+        return skill_path[: -len("/SKILL.md")]
+    return skill_path
+
+
+def _drop_lock_entry(name: str) -> None:
+    lock = _lock_load()
+    if lock.get("skills", {}).pop(name, None) is not None:
+        _lock_save(lock)
+
+
+def _migrate_one(name: str, entry: dict) -> None:
+    if core.registry_get(name) is not None:
+        _drop_lock_entry(name)
+        return
+
+    src = _npx_skill_dir(name)
+    paths = core.paths_for(name)
+    for dst in (paths.active, paths.baseline, paths.upstream):
+        core.copy_tree(src, dst)
+
+    paths.symlink.parent.mkdir(parents=True, exist_ok=True)
+    if paths.symlink.is_symlink() or paths.symlink.exists():
+        paths.symlink.unlink()
+    paths.symlink.symlink_to(paths.active)
+
+    repo = entry["source"]
+    path = _path_from_skillpath(entry["skillPath"])
+    ref = entry.get("skillFolderHash", "HEAD")
+    core.registry_set(name, repo, path, ref)
+    core.audit_append("migrate", name)
+    _drop_lock_entry(name)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="migrate.py")
+    parser.add_argument("name", nargs="?")
+    args = parser.parse_args(argv)
+
+    lock = _lock_load()
+    skills = lock.get("skills", {})
+
+    if args.name is not None:
+        entry = skills.get(args.name)
+        if entry is None:
+            return 0
+        _migrate_one(args.name, entry)
+        return 0
+
+    for name, entry in list(skills.items()):
+        _migrate_one(name, entry)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,133 @@
+import json
+
+import migrate
+
+
+def _seed_npx(home, name, skill_path, source, hash_, files):
+    """Lay down ~/.agents/skills/<name>/<files> and a .skill-lock.json entry."""
+    skill_dir = home / ".agents" / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        p = skill_dir / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+
+    lock = home / ".agents" / ".skill-lock.json"
+    data = json.loads(lock.read_text()) if lock.exists() else {"version": 3, "skills": {}}
+    data["skills"][name] = {
+        "source": source,
+        "sourceType": "github",
+        "sourceUrl": f"https://github.com/{source}.git",
+        "skillPath": skill_path,
+        "skillFolderHash": hash_,
+        "installedAt": "2026-04-01T00:00:00.000Z",
+        "updatedAt": "2026-04-01T00:00:00.000Z",
+    }
+    lock.write_text(json.dumps(data))
+
+
+def test_migrate_named_skill_populates_three_trees_and_symlink_and_registry(home):
+    _seed_npx(
+        home,
+        "widget",
+        "skills/widget/SKILL.md",
+        "acme/skills",
+        "abc123",
+        {"SKILL.md": "---\nname: widget\n---\n# v1\n", "helper.py": "x = 1\n"},
+    )
+
+    rc = migrate.main(["widget"])
+    assert rc == 0
+
+    base = home / ".agents" / "sync-skills" / "widget"
+    for layer in ("active", "baseline", "upstream"):
+        assert (base / layer / "SKILL.md").read_text() == "---\nname: widget\n---\n# v1\n"
+        assert (base / layer / "helper.py").read_text() == "x = 1\n"
+
+    symlink = home / ".claude" / "skills" / "widget"
+    assert symlink.is_symlink()
+    assert symlink.resolve() == (base / "active").resolve()
+
+    registry = json.loads((home / ".agents" / "sync-skills" / "sources.json").read_text())
+    assert registry == {
+        "widget": {"repo": "acme/skills", "path": "skills/widget", "ref": "abc123"}
+    }
+
+    lock = json.loads((home / ".agents" / ".skill-lock.json").read_text())
+    assert "widget" not in lock["skills"]
+
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert len(history) == 1
+    assert "migrate" in history[0] and "widget" in history[0]
+
+
+def test_migrate_derives_path_for_flat_layout(home):
+    # mattpocock/skills layout: skill at repo root, skillPath = "<name>/SKILL.md".
+    _seed_npx(home, "tdd", "tdd/SKILL.md", "mattpocock/skills", "deadbeef", {"SKILL.md": "v\n"})
+
+    migrate.main(["tdd"])
+
+    registry = json.loads((home / ".agents" / "sync-skills" / "sources.json").read_text())
+    assert registry["tdd"] == {
+        "repo": "mattpocock/skills",
+        "path": "tdd",
+        "ref": "deadbeef",
+    }
+
+
+def test_migrate_is_noop_when_already_migrated(home):
+    _seed_npx(home, "widget", "widget/SKILL.md", "x/skills", "h", {"SKILL.md": "v1\n"})
+    migrate.main(["widget"])
+
+    # User customizes active/ after migration; lock somehow still names it.
+    base = home / ".agents" / "sync-skills" / "widget"
+    (base / "active" / "SKILL.md").write_text("my custom\n")
+    lock_path = home / ".agents" / ".skill-lock.json"
+    lock = json.loads(lock_path.read_text())
+    lock["skills"]["widget"] = {
+        "source": "x/skills",
+        "skillPath": "widget/SKILL.md",
+        "skillFolderHash": "h",
+    }
+    lock_path.write_text(json.dumps(lock))
+
+    rc = migrate.main(["widget"])
+    assert rc == 0
+
+    # Active untouched, no extra audit event, lock entry cleaned up.
+    assert (base / "active" / "SKILL.md").read_text() == "my custom\n"
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert len(history) == 1
+    lock = json.loads(lock_path.read_text())
+    assert "widget" not in lock["skills"]
+
+
+def test_migrate_replaces_preexisting_symlink_into_npx_skills(home):
+    _seed_npx(home, "widget", "widget/SKILL.md", "x/skills", "h", {"SKILL.md": "v\n"})
+    symlink = home / ".claude" / "skills" / "widget"
+    symlink.symlink_to(home / ".agents" / "skills" / "widget")
+
+    rc = migrate.main(["widget"])
+    assert rc == 0
+
+    expected = home / ".agents" / "sync-skills" / "widget" / "active"
+    assert symlink.is_symlink()
+    assert symlink.resolve() == expected.resolve()
+
+
+def test_migrate_with_no_name_migrates_every_locked_skill(home):
+    _seed_npx(home, "alpha", "alpha/SKILL.md", "x/skills", "h1", {"SKILL.md": "a\n"})
+    _seed_npx(home, "beta", "beta/SKILL.md", "x/skills", "h2", {"SKILL.md": "b\n"})
+
+    rc = migrate.main([])
+    assert rc == 0
+
+    base = home / ".agents" / "sync-skills"
+    assert (base / "alpha" / "active" / "SKILL.md").read_text() == "a\n"
+    assert (base / "beta" / "active" / "SKILL.md").read_text() == "b\n"
+
+    registry = json.loads((base / "sources.json").read_text())
+    assert set(registry.keys()) == {"alpha", "beta"}
+
+    lock = json.loads((home / ".agents" / ".skill-lock.json").read_text())
+    assert lock["skills"] == {}


### PR DESCRIPTION
Closes #7.

## Summary
- `scripts/migrate.py` reads `~/.agents/.skill-lock.json`, copies `~/.agents/skills/<name>/` into all three sync-skills trees, swings `~/.claude/skills/<name>` to `active/`, registers in `sources.json`, removes the lock entry, and audits `migrate`.
- With no name, migrates every entry in the lock file.
- Already-registered skills skip the copy/audit but still drop the lock entry to converge state.
- Lock-field mapping: `source` → `repo`, `skillPath` minus trailing `/SKILL.md` → `path`, `skillFolderHash` → `ref`. Handles both `skills/<name>/SKILL.md` (vercel-labs) and `<name>/SKILL.md` (mattpocock) layouts.

## Test plan
- [x] `uv run pytest` — 12/12 pass (5 new in `tests/test_migrate.py` covering: named happy path, all-skills mode, symlink replace, no-op re-run, flat-layout path derivation).
- [ ] Smoke: run `python3 scripts/migrate.py grill-me` against real `~/.agents/.skill-lock.json` and verify `sources.json` + symlink + lock entry removal.