### PR TITLE
Cherry-pick primitives: parse_hunks + backup_active

### DIFF
--- a/scripts/core.py
+++ b/scripts/core.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import tempfile
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple
@@ -20,6 +21,68 @@ class Paths(NamedTuple):
     baseline: Path
     upstream: Path
     symlink: Path
+
+
+@dataclass
+class Hunk:
+    file: str
+    old_string: str
+    new_string: str
+
+
+def parse_hunks(diff_text: str) -> list[Hunk]:
+    hunks: list[Hunk] = []
+    current_file: str | None = None
+    old: list[str] = []
+    new: list[str] = []
+    in_hunk = False
+    last_old = False
+    last_new = False
+
+    def flush() -> None:
+        if in_hunk and current_file is not None:
+            hunks.append(Hunk(current_file, "".join(old), "".join(new)))
+
+    def strip_trailing_newline(buf: list[str]) -> None:
+        if buf and buf[-1].endswith("\n"):
+            buf[-1] = buf[-1][:-1]
+
+    for line in diff_text.splitlines(keepends=True):
+        if line.startswith("+++ "):
+            flush()
+            in_hunk = False
+            path = line[4:].rstrip("\n")
+            current_file = path[2:] if path.startswith("b/") else path
+            continue
+        if line.startswith("--- "):
+            continue
+        if line.startswith("@@"):
+            flush()
+            old, new = [], []
+            in_hunk = True
+            last_old = last_new = False
+            continue
+        if not in_hunk:
+            continue
+        if line.startswith("\\"):
+            if last_old:
+                strip_trailing_newline(old)
+            if last_new:
+                strip_trailing_newline(new)
+            continue
+        if line.startswith(" "):
+            old.append(line[1:])
+            new.append(line[1:])
+            last_old = last_new = True
+        elif line.startswith("-"):
+            old.append(line[1:])
+            last_old, last_new = True, False
+        elif line.startswith("+"):
+            new.append(line[1:])
+            last_old, last_new = False, True
+
+    flush()
+    return hunks
 
 
 def root() -> Path:
@@ -40,6 +103,13 @@ def copy_tree(src: Path, dst: Path) -> None:
     if dst.exists():
         shutil.rmtree(dst)
     shutil.copytree(src, dst)
+
+
+def backup_active(name: str) -> Path:
+    src = paths_for(name).active / "SKILL.md"
+    dst = src.with_name("SKILL.md.bak")
+    shutil.copy2(src, dst)
+    return dst
 
 
 def _registry_file() -> Path:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,33 @@
+from core import backup_active, paths_for
+
+
+def test_bak_created_when_absent(home):
+    active = paths_for("w").active
+    active.mkdir(parents=True)
+    (active / "SKILL.md").write_text("v1\n")
+
+    bak = backup_active("w")
+
+    assert bak == active / "SKILL.md.bak"
+    assert bak.read_text() == "v1\n"
+
+
+def test_bak_overwrites_existing(home):
+    active = paths_for("w").active
+    active.mkdir(parents=True)
+    (active / "SKILL.md").write_text("current\n")
+    (active / "SKILL.md.bak").write_text("stale\n")
+
+    backup_active("w")
+
+    assert (active / "SKILL.md.bak").read_text() == "current\n"
+
+
+def test_bak_leaves_original_untouched(home):
+    active = paths_for("w").active
+    active.mkdir(parents=True)
+    (active / "SKILL.md").write_text("the original\n")
+
+    backup_active("w")
+
+    assert (active / "SKILL.md").read_text() == "the original\n"

--- a/tests/test_diff_parser.py
+++ b/tests/test_diff_parser.py
@@ -1,0 +1,113 @@
+from core import parse_hunks
+
+
+def test_single_hunk_diff():
+    diff = """\
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,3 +1,3 @@
+ line one
+-old middle
++new middle
+ line three
+"""
+    hunks = parse_hunks(diff)
+    assert len(hunks) == 1
+    h = hunks[0]
+    assert h.file == "SKILL.md"
+    assert h.old_string == "line one\nold middle\nline three\n"
+    assert h.new_string == "line one\nnew middle\nline three\n"
+
+
+def test_multi_hunk_same_file():
+    diff = """\
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++BETA
+ gamma
+@@ -10,3 +10,3 @@
+ delta
+-epsilon
++EPSILON
+ zeta
+"""
+    hunks = parse_hunks(diff)
+    assert len(hunks) == 2
+    assert all(h.file == "SKILL.md" for h in hunks)
+    assert hunks[0].old_string == "alpha\nbeta\ngamma\n"
+    assert hunks[0].new_string == "alpha\nBETA\ngamma\n"
+    assert hunks[1].old_string == "delta\nepsilon\nzeta\n"
+    assert hunks[1].new_string == "delta\nEPSILON\nzeta\n"
+
+
+def test_multi_file_diff():
+    diff = """\
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,3 +1,3 @@
+ a
+-old
++new
+ b
+--- a/helper.py
++++ b/helper.py
+@@ -1,3 +1,3 @@
+ import os
+-x = 1
++x = 2
+ y = 3
+"""
+    hunks = parse_hunks(diff)
+    assert len(hunks) == 2
+    assert hunks[0].file == "SKILL.md"
+    assert hunks[1].file == "helper.py"
+
+
+def test_hunk_at_top_of_file():
+    diff = """\
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,2 +1,2 @@
+-old first line
++new first line
+ second line
+"""
+    hunks = parse_hunks(diff)
+    assert len(hunks) == 1
+    assert hunks[0].old_string == "old first line\nsecond line\n"
+    assert hunks[0].new_string == "new first line\nsecond line\n"
+
+
+def test_hunk_at_bottom_of_file():
+    diff = """\
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -2,2 +2,2 @@
+ second to last
+-old last line
++new last line
+"""
+    hunks = parse_hunks(diff)
+    assert len(hunks) == 1
+    assert hunks[0].old_string == "second to last\nold last line\n"
+    assert hunks[0].new_string == "second to last\nnew last line\n"
+
+
+def test_no_trailing_newline_marker():
+    diff = """\
+--- a/SKILL.md
++++ b/SKILL.md
+@@ -1,2 +1,2 @@
+ keep
+-old
+\\ No newline at end of file
++new
+\\ No newline at end of file
+"""
+    hunks = parse_hunks(diff)
+    assert len(hunks) == 1
+    assert hunks[0].old_string == "keep\nold"
+    assert hunks[0].new_string == "keep\nnew"


### PR DESCRIPTION
## Summary
- `parse_hunks(diff_text)` returns a list of `Hunk(file, old_string, new_string)` shaped for the `Edit` tool — handles single/multi-hunk, multi-file, top/bottom-of-file, and `\ No newline at end of file`.
- `backup_active(name)` snapshots `<sync_root>/<name>/active/SKILL.md` to `SKILL.md.bak` (overwrites). To be called before each `Edit` during cherry-pick.
- Both live in `scripts/core.py`; 9 behavioural tests across `tests/test_diff_parser.py` + `tests/test_backup.py`.

Closes #6. Unblocks the cherry-pick path of #9; the markdown `SKILL.md` flow + grill-me smoke ship in a follow-up.

## Test plan
- [x] `uv run pytest` — 21/21 green
- [ ] Reviewer eyeballs the parser against a real `git diff` of two SKILL.md versions before merge