### PR TITLE
Relink script: cross-machine restore of skill symlinks (closes #8)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -15,11 +15,12 @@ Self-contained Python 3, stdlib only. Run directly:
 python3 ~/.claude/skills/sync-skills/scripts/install.py <name> <owner/repo> <path> [ref]
 python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
 python3 ~/.claude/skills/sync-skills/scripts/migrate.py [name]
+python3 ~/.claude/skills/sync-skills/scripts/relink.py
 ```
 
-`install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`. `migrate` ports a skill installed via `npx skills` (vercel-labs/skills) into sync-skills: copies `~/.agents/skills/<name>/` into all three trees, swings the symlink, registers it, and removes the entry from `~/.agents/.skill-lock.json`. With no name, migrates every entry in the lock file.
+`install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`. `migrate` ports a skill installed via `npx skills` (vercel-labs/skills) into sync-skills: copies `~/.agents/skills/<name>/` into all three trees, swings the symlink, registers it, and removes the entry from `~/.agents/.skill-lock.json`. With no name, migrates every entry in the lock file. `relink` recreates every `~/.claude/skills/<name>` symlink from `sources.json` — the cross-machine restore: drop a saved `~/.agents/sync-skills/` folder onto a fresh machine, run `relink`, all symlinks come back. Idempotent; refuses to overwrite a non-symlink at the target path.
 
-More scripts (`relink`, `doctor`) and the interactive `/sync-skills` review flow land in follow-up issues. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
+More scripts (`doctor`) and the interactive `/sync-skills` review flow land in follow-up issues. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
 
 ## Inspecting state
 

--- a/scripts/relink.py
+++ b/scripts/relink.py
@@ -1,0 +1,38 @@
+"""Recreate every ~/.claude/skills/<name> symlink from sources.json.
+Idempotent. Cross-machine restore: drop a saved ~/.agents/sync-skills/ folder
+on a fresh machine, run this, get all Claude-visible symlinks back."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import core
+
+
+def main(argv: list[str] | None = None) -> int:
+    argparse.ArgumentParser(prog="relink.py").parse_args(argv)
+
+    rc = 0
+    for name in core.registry_load():
+        paths = core.paths_for(name)
+        if not paths.active.is_dir():
+            print(f"skipping {name}: missing {paths.active}", file=sys.stderr)
+            rc = 1
+            continue
+        if paths.symlink.is_symlink() and paths.symlink.resolve() == paths.active.resolve():
+            continue
+        if paths.symlink.exists() and not paths.symlink.is_symlink():
+            print(f"refusing to overwrite non-symlink at {paths.symlink} ({name})", file=sys.stderr)
+            rc = 1
+            continue
+        paths.symlink.parent.mkdir(parents=True, exist_ok=True)
+        if paths.symlink.is_symlink():
+            paths.symlink.unlink()
+        paths.symlink.symlink_to(paths.active)
+        core.audit_append("relink", name)
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_relink.py
+++ b/tests/test_relink.py
@@ -1,0 +1,141 @@
+import install
+import relink
+
+
+def test_relink_creates_missing_symlink(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo("acme/w", "skills/w", {"SKILL.md": "v1\n"})
+    install.main(["w", repo_url, "skills/w"])
+
+    link = home / ".claude" / "skills" / "w"
+    link.unlink()
+    assert not link.exists()
+
+    rc = relink.main([])
+    assert rc == 0
+
+    target = home / ".agents" / "sync-skills" / "w" / "active"
+    assert link.is_symlink()
+    assert link.resolve() == target.resolve()
+
+
+def test_relink_skips_skill_with_missing_active(home, fake_upstream_repo, capsys):
+    import shutil
+
+    repo_a = fake_upstream_repo("acme/a", "skills/a", {"SKILL.md": "a\n"})
+    repo_b = fake_upstream_repo("acme/b", "skills/b", {"SKILL.md": "b\n"})
+    install.main(["a", repo_a, "skills/a"])
+    install.main(["b", repo_b, "skills/b"])
+
+    sync_root = home / ".agents" / "sync-skills"
+    shutil.rmtree(sync_root / "a" / "active")
+
+    skills_dir = home / ".claude" / "skills"
+    (skills_dir / "a").unlink()
+    (skills_dir / "b").unlink()
+
+    rc = relink.main([])
+    assert rc != 0
+
+    assert not (skills_dir / "a").exists()
+    assert (skills_dir / "b").resolve() == (sync_root / "b" / "active").resolve()
+
+    err = capsys.readouterr().err
+    assert "a" in err
+
+
+def test_relink_appends_audit_event_per_relinked_skill(home, fake_upstream_repo):
+    repo_a = fake_upstream_repo("acme/a", "skills/a", {"SKILL.md": "a\n"})
+    repo_b = fake_upstream_repo("acme/b", "skills/b", {"SKILL.md": "b\n"})
+    install.main(["a", repo_a, "skills/a"])
+    install.main(["b", repo_b, "skills/b"])
+
+    skills_dir = home / ".claude" / "skills"
+    (skills_dir / "a").unlink()
+    (skills_dir / "b").unlink()
+
+    relink.main([])
+
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    relink_lines = [line for line in history if "\trelink\t" in line]
+    assert len(relink_lines) == 2
+    assert any(line.endswith("\ta") for line in relink_lines)
+    assert any(line.endswith("\tb") for line in relink_lines)
+
+
+def test_relink_empty_registry_is_clean_exit(home):
+    rc = relink.main([])
+    assert rc == 0
+    history = home / ".agents" / "sync-skills" / "history.log"
+    assert not history.exists()
+
+
+def test_relink_refuses_to_overwrite_non_symlink(home, fake_upstream_repo, capsys):
+    repo_a = fake_upstream_repo("acme/a", "skills/a", {"SKILL.md": "a\n"})
+    repo_b = fake_upstream_repo("acme/b", "skills/b", {"SKILL.md": "b\n"})
+    install.main(["a", repo_a, "skills/a"])
+    install.main(["b", repo_b, "skills/b"])
+
+    skills_dir = home / ".claude" / "skills"
+    (skills_dir / "a").unlink()
+    (skills_dir / "a").write_text("hand-rolled\n")
+    (skills_dir / "b").unlink()
+
+    rc = relink.main([])
+    assert rc != 0
+
+    assert (skills_dir / "a").is_file() and not (skills_dir / "a").is_symlink()
+    assert (skills_dir / "a").read_text() == "hand-rolled\n"
+
+    sync_root = home / ".agents" / "sync-skills"
+    assert (skills_dir / "b").resolve() == (sync_root / "b" / "active").resolve()
+
+    err = capsys.readouterr().err
+    assert "a" in err
+
+
+def test_relink_is_noop_when_symlink_already_correct(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo("acme/w", "skills/w", {"SKILL.md": "v1\n"})
+    install.main(["w", repo_url, "skills/w"])
+
+    history = home / ".agents" / "sync-skills" / "history.log"
+    before = history.read_text()
+
+    rc = relink.main([])
+    assert rc == 0
+
+    assert history.read_text() == before
+
+
+def test_relink_replaces_wrong_target(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo("acme/w", "skills/w", {"SKILL.md": "v1\n"})
+    install.main(["w", repo_url, "skills/w"])
+
+    link = home / ".claude" / "skills" / "w"
+    elsewhere = home / "elsewhere"
+    elsewhere.mkdir()
+    link.unlink()
+    link.symlink_to(elsewhere)
+
+    rc = relink.main([])
+    assert rc == 0
+
+    target = home / ".agents" / "sync-skills" / "w" / "active"
+    assert link.resolve() == target.resolve()
+
+
+def test_relink_handles_multiple_skills(home, fake_upstream_repo):
+    repo_a = fake_upstream_repo("acme/a", "skills/a", {"SKILL.md": "a\n"})
+    repo_b = fake_upstream_repo("acme/b", "skills/b", {"SKILL.md": "b\n"})
+    install.main(["a", repo_a, "skills/a"])
+    install.main(["b", repo_b, "skills/b"])
+
+    skills_dir = home / ".claude" / "skills"
+    (skills_dir / "a").unlink()
+    (skills_dir / "b").unlink()
+
+    rc = relink.main([])
+    assert rc == 0
+
+    sync_root = home / ".agents" / "sync-skills"
+    assert (skills_dir / "a").resolve() == (sync_root / "a" / "active").resolve()
+    assert (skills_dir / "b").resolve() == (sync_root / "b" / "active").resolve()


### PR DESCRIPTION
## Summary

- `scripts/relink.py` recreates every `~/.claude/skills/<name>` symlink from `sources.json`. Cross-machine restore: drop a saved `~/.agents/sync-skills/` onto a fresh machine, run this, every Claude-visible symlink comes back.
- Idempotent (skips already-correct), refuses to overwrite a real file/dir at the target path (nonzero rc, continues), skips skills with a missing `active/` tree (nonzero rc, continues).
- Audit `relink` event per (re)linked skill.
- The `remove` half of #8 is **not landed as a script** — per the post-#3 reshape, `remove` becomes a one-liner in SKILL.md once the `/sync-skills` flow lands (drop registry entry, unlink symlink). #8 closes here.

8 behavioural tests in `tests/test_relink.py`.

Closes #8.