### PR TITLE
Doctor script: diagnose and fix six known state-drift modes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -16,11 +16,12 @@ python3 ~/.claude/skills/sync-skills/scripts/install.py <name> <owner/repo> <pat
 python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
 python3 ~/.claude/skills/sync-skills/scripts/migrate.py [name]
 python3 ~/.claude/skills/sync-skills/scripts/relink.py
+python3 ~/.claude/skills/sync-skills/scripts/doctor.py [--yes]
 ```
 
-`install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`. `migrate` ports a skill installed via `npx skills` (vercel-labs/skills) into sync-skills: copies `~/.agents/skills/<name>/` into all three trees, swings the symlink, registers it, and removes the entry from `~/.agents/.skill-lock.json`. With no name, migrates every entry in the lock file. `relink` recreates every `~/.claude/skills/<name>` symlink from `sources.json` — the cross-machine restore: drop a saved `~/.agents/sync-skills/` folder onto a fresh machine, run `relink`, all symlinks come back. Idempotent; refuses to overwrite a non-symlink at the target path.
+`install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`. `migrate` ports a skill installed via `npx skills` (vercel-labs/skills) into sync-skills: copies `~/.agents/skills/<name>/` into all three trees, swings the symlink, registers it, and removes the entry from `~/.agents/.skill-lock.json`. With no name, migrates every entry in the lock file. `relink` recreates every `~/.claude/skills/<name>` symlink from `sources.json` — the cross-machine restore: drop a saved `~/.agents/sync-skills/` folder onto a fresh machine, run `relink`, all symlinks come back. Idempotent; refuses to overwrite a non-symlink at the target path. `doctor` scans for the six known state-drift failure modes (broken symlink, vercel clobber + stranded edits, registry orphan, folder orphan, double-managed lock entry, missing layer) and prints findings; pass `--yes` to apply every proposed fix. Each applied fix appends a `doctor-fix` audit event.
 
-More scripts (`doctor`) and the interactive `/sync-skills` review flow land in follow-up issues. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
+The interactive `/sync-skills` review flow lands in a follow-up issue. Trivial operations (list, fetch, diff, remove) are inline `Bash` calls in this file once the review flow lands.
 
 ## Inspecting state
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -1,0 +1,274 @@
+"""Diagnose state drift across sync-skills, vercel-labs/skills, and the Claude
+symlink directory. Each diagnosis is independently callable; a fix is attached
+to every Issue so callers can apply selectively."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import core
+
+
+def _npx_dir(name: str) -> Path:
+    return Path(os.environ["HOME"]) / ".agents" / "skills" / name
+
+
+def _lock_path() -> Path:
+    return Path(os.environ["HOME"]) / ".agents" / ".skill-lock.json"
+
+
+def _lock_load() -> dict:
+    p = _lock_path()
+    if not p.exists():
+        return {"version": 3, "skills": {}}
+    return json.loads(p.read_text())
+
+
+def _lock_save(data: dict) -> None:
+    _lock_path().write_text(json.dumps(data, indent=2) + "\n")
+
+
+@dataclass
+class Issue:
+    kind: str
+    skill: str
+    summary: str
+    apply: Callable[[], None]
+
+
+def _fix_symlink(name: str) -> Callable[[], None]:
+    def apply() -> None:
+        paths = core.paths_for(name)
+        paths.symlink.parent.mkdir(parents=True, exist_ok=True)
+        if paths.symlink.is_symlink() or paths.symlink.exists():
+            paths.symlink.unlink()
+        paths.symlink.symlink_to(paths.active)
+        core.audit_append("doctor-fix", name)
+
+    return apply
+
+
+def _import_stranded_edit(name: str) -> Callable[[], None]:
+    def apply() -> None:
+        src = _npx_dir(name) / "SKILL.md"
+        dst = core.paths_for(name).active / "SKILL.md"
+        shutil.copy2(src, dst)
+        core.audit_append("doctor-fix", name)
+
+    return apply
+
+
+def _points_into_npx(symlink: Path, name: str) -> bool:
+    if not symlink.is_symlink():
+        return False
+    try:
+        return symlink.resolve() == _npx_dir(name).resolve()
+    except OSError:
+        return False
+
+
+def _check_symlinks() -> list[Issue]:
+    issues: list[Issue] = []
+    for name in core.registry_load():
+        paths = core.paths_for(name)
+        if not paths.active.is_dir():
+            continue
+        if paths.symlink.is_symlink() and paths.symlink.resolve() == paths.active.resolve():
+            continue
+        if paths.symlink.exists() and not paths.symlink.is_symlink():
+            continue
+
+        if _points_into_npx(paths.symlink, name):
+            issues.append(
+                Issue(
+                    kind="symlink-clobber",
+                    skill=name,
+                    summary=f"~/.claude/skills/{name} points into ~/.agents/skills/{name} (vercel clobber)",
+                    apply=_fix_symlink(name),
+                )
+            )
+            npx_skill = _npx_dir(name) / "SKILL.md"
+            active_skill = paths.active / "SKILL.md"
+            if (
+                npx_skill.is_file()
+                and active_skill.is_file()
+                and npx_skill.read_bytes() != active_skill.read_bytes()
+            ):
+                issues.append(
+                    Issue(
+                        kind="stranded-edit",
+                        skill=name,
+                        summary=f"~/.agents/skills/{name}/SKILL.md has edits not in active/",
+                        apply=_import_stranded_edit(name),
+                    )
+                )
+        else:
+            issues.append(
+                Issue(
+                    kind="symlink-missing",
+                    skill=name,
+                    summary=f"~/.claude/skills/{name} missing or points to wrong target",
+                    apply=_fix_symlink(name),
+                )
+            )
+    return issues
+
+
+def _drop_registry_entry(name: str) -> Callable[[], None]:
+    def apply() -> None:
+        data = core.registry_load()
+        data.pop(name, None)
+        core.registry_save(data)
+        core.audit_append("doctor-fix", name)
+
+    return apply
+
+
+def _check_registry_orphans() -> list[Issue]:
+    issues: list[Issue] = []
+    for name in core.registry_load():
+        if not (core.root() / name).is_dir():
+            issues.append(
+                Issue(
+                    kind="registry-orphan",
+                    skill=name,
+                    summary=f"sources.json has {name} but ~/.agents/sync-skills/{name}/ is missing",
+                    apply=_drop_registry_entry(name),
+                )
+            )
+    return issues
+
+
+def _delete_folder(name: str) -> Callable[[], None]:
+    def apply() -> None:
+        shutil.rmtree(core.root() / name)
+        core.audit_append("doctor-fix", name)
+
+    return apply
+
+
+def _check_folder_orphans() -> list[Issue]:
+    issues: list[Issue] = []
+    sync = core.root()
+    if not sync.is_dir():
+        return issues
+    registered = set(core.registry_load().keys())
+    for entry in sorted(sync.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name in registered:
+            continue
+        issues.append(
+            Issue(
+                kind="folder-orphan",
+                skill=entry.name,
+                summary=f"~/.agents/sync-skills/{entry.name}/ exists but is not in sources.json",
+                apply=_delete_folder(entry.name),
+            )
+        )
+    return issues
+
+
+def _drop_lock_entry(name: str) -> Callable[[], None]:
+    def apply() -> None:
+        lock = _lock_load()
+        if lock.get("skills", {}).pop(name, None) is not None:
+            _lock_save(lock)
+        core.audit_append("doctor-fix", name)
+
+    return apply
+
+
+def _check_double_managed() -> list[Issue]:
+    issues: list[Issue] = []
+    locked = set(_lock_load().get("skills", {}).keys())
+    for name in core.registry_load():
+        if name in locked:
+            issues.append(
+                Issue(
+                    kind="double-managed",
+                    skill=name,
+                    summary=f"{name} is in both sources.json and .skill-lock.json",
+                    apply=_drop_lock_entry(name),
+                )
+            )
+    return issues
+
+
+def _refetch_missing_layers(name: str, missing: list[str]) -> Callable[[], None]:
+    def apply() -> None:
+        entry = core.registry_get(name) or {}
+        paths = core.paths_for(name)
+        with core.fetch(entry["repo"], entry["path"], entry.get("ref", "HEAD")) as src:
+            for layer in missing:
+                core.copy_tree(src, getattr(paths, layer))
+        core.audit_append("doctor-fix", name)
+
+    return apply
+
+
+def _check_missing_layers() -> list[Issue]:
+    issues: list[Issue] = []
+    for name in core.registry_load():
+        paths = core.paths_for(name)
+        if not (core.root() / name).is_dir():
+            continue
+        missing = [
+            layer for layer in ("active", "baseline", "upstream")
+            if not getattr(paths, layer).is_dir()
+        ]
+        if missing:
+            issues.append(
+                Issue(
+                    kind="missing-layers",
+                    skill=name,
+                    summary=f"{name} is missing layer(s): {', '.join(missing)}",
+                    apply=_refetch_missing_layers(name, missing),
+                )
+            )
+    return issues
+
+
+def diagnose() -> list[Issue]:
+    return (
+        _check_symlinks()
+        + _check_registry_orphans()
+        + _check_folder_orphans()
+        + _check_double_managed()
+        + _check_missing_layers()
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="doctor.py")
+    parser.add_argument("--yes", action="store_true", help="apply every proposed fix without prompting")
+    args = parser.parse_args(argv)
+
+    issues = diagnose()
+    if not issues:
+        print("clean bill of health")
+        return 0
+
+    print(f"found {len(issues)} issue(s):")
+    for i in issues:
+        print(f"  [{i.kind}] {i.summary}")
+
+    if not args.yes:
+        print("\nre-run with --yes to apply every proposed fix.")
+        return 0
+
+    for i in issues:
+        i.apply()
+        print(f"fixed: [{i.kind}] {i.skill}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,293 @@
+import doctor
+import install
+
+
+def _install(home, fake_upstream_repo, name="w", content="v\n"):
+    repo = fake_upstream_repo(f"acme/{name}", f"skills/{name}", {"SKILL.md": content})
+    install.main([name, repo, f"skills/{name}"])
+
+
+def test_diagnose_clean_state_returns_no_issues(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    assert doctor.diagnose() == []
+
+
+def test_diagnose_flags_missing_symlink(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    (home / ".claude" / "skills" / "w").unlink()
+
+    issues = doctor.diagnose()
+    kinds = [(i.kind, i.skill) for i in issues]
+    assert ("symlink-missing", "w") in kinds
+
+
+def test_fix_recreates_missing_symlink_with_audit(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    link = home / ".claude" / "skills" / "w"
+    link.unlink()
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "symlink-missing"]
+    issue.apply()
+
+    target = home / ".agents" / "sync-skills" / "w" / "active"
+    assert link.is_symlink() and link.resolve() == target.resolve()
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert any("\tdoctor-fix\t" in line and line.endswith("\tw") for line in history)
+
+
+def test_diagnose_flags_symlink_pointing_to_wrong_target(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    link = home / ".claude" / "skills" / "w"
+    elsewhere = home / "elsewhere"
+    elsewhere.mkdir()
+    link.unlink()
+    link.symlink_to(elsewhere)
+
+    issues = doctor.diagnose()
+    assert any(i.kind == "symlink-missing" and i.skill == "w" for i in issues)
+
+
+def _make_clobber(home, name="w", npx_content="v\n"):
+    """Lay down ~/.agents/skills/<name>/ and point ~/.claude/skills/<name> at it."""
+    npx_dir = home / ".agents" / "skills" / name
+    npx_dir.mkdir(parents=True)
+    (npx_dir / "SKILL.md").write_text(npx_content)
+    link = home / ".claude" / "skills" / name
+    link.unlink()
+    link.symlink_to(npx_dir)
+
+
+def test_diagnose_flags_vercel_clobber_separately_from_generic_wrong_target(
+    home, fake_upstream_repo
+):
+    _install(home, fake_upstream_repo)
+    _make_clobber(home)
+
+    issues = doctor.diagnose()
+    kinds = [i.kind for i in issues if i.skill == "w"]
+    assert "symlink-clobber" in kinds
+    assert "symlink-missing" not in kinds
+
+
+def test_fix_clobber_resymlinks_to_active_with_audit(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    _make_clobber(home)
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "symlink-clobber"]
+    issue.apply()
+
+    link = home / ".claude" / "skills" / "w"
+    target = home / ".agents" / "sync-skills" / "w" / "active"
+    assert link.resolve() == target.resolve()
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert any("\tdoctor-fix\t" in line and line.endswith("\tw") for line in history)
+
+
+def test_diagnose_flags_stranded_edit_when_npx_skill_diverges_from_active(
+    home, fake_upstream_repo
+):
+    _install(home, fake_upstream_repo)
+    _make_clobber(home, npx_content="HAND-EDITED\n")
+
+    issues = doctor.diagnose()
+    kinds = [i.kind for i in issues if i.skill == "w"]
+    assert "stranded-edit" in kinds
+    assert "symlink-clobber" in kinds
+
+
+def test_no_stranded_edit_when_npx_matches_active(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    _make_clobber(home, npx_content="v\n")
+
+    kinds = [i.kind for i in doctor.diagnose() if i.skill == "w"]
+    assert "stranded-edit" not in kinds
+
+
+def test_fix_stranded_edit_imports_npx_file_into_active(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    _make_clobber(home, npx_content="HAND-EDITED\n")
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "stranded-edit"]
+    issue.apply()
+
+    active_skill = home / ".agents" / "sync-skills" / "w" / "active" / "SKILL.md"
+    assert active_skill.read_text() == "HAND-EDITED\n"
+
+
+def test_diagnose_flags_registry_orphan_when_skill_folder_is_missing(
+    home, fake_upstream_repo
+):
+    import shutil as _shutil
+
+    _install(home, fake_upstream_repo)
+    _shutil.rmtree(home / ".agents" / "sync-skills" / "w")
+
+    issues = doctor.diagnose()
+    kinds = [(i.kind, i.skill) for i in issues]
+    assert ("registry-orphan", "w") in kinds
+
+
+def test_fix_registry_orphan_removes_entry_with_audit(home, fake_upstream_repo):
+    import json
+    import shutil as _shutil
+
+    _install(home, fake_upstream_repo)
+    _shutil.rmtree(home / ".agents" / "sync-skills" / "w")
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "registry-orphan"]
+    issue.apply()
+
+    sources = home / ".agents" / "sync-skills" / "sources.json"
+    assert json.loads(sources.read_text()) == {}
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert any("\tdoctor-fix\t" in line and line.endswith("\tw") for line in history)
+
+
+def test_diagnose_flags_folder_orphan_for_unregistered_directory(home):
+    sync = home / ".agents" / "sync-skills"
+    (sync / "stray" / "active").mkdir(parents=True)
+    (sync / "stray" / "active" / "SKILL.md").write_text("v\n")
+
+    issues = doctor.diagnose()
+    assert any(i.kind == "folder-orphan" and i.skill == "stray" for i in issues)
+
+
+def test_diagnose_ignores_registry_and_history_files_at_sync_root(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    issues = doctor.diagnose()
+    assert all(i.skill != "sources.json" for i in issues)
+    assert all(i.skill != "history.log" for i in issues)
+
+
+def test_fix_folder_orphan_deletes_directory(home):
+    sync = home / ".agents" / "sync-skills"
+    (sync / "stray" / "active").mkdir(parents=True)
+    (sync / "stray" / "active" / "SKILL.md").write_text("v\n")
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "folder-orphan"]
+    issue.apply()
+
+    assert not (sync / "stray").exists()
+
+
+def _seed_lock_entry(home, name):
+    import json as _json
+
+    lock = home / ".agents" / ".skill-lock.json"
+    data = _json.loads(lock.read_text()) if lock.exists() else {"version": 3, "skills": {}}
+    data["skills"][name] = {
+        "source": "x/skills",
+        "skillPath": f"{name}/SKILL.md",
+        "skillFolderHash": "h",
+    }
+    lock.write_text(_json.dumps(data))
+
+
+def test_diagnose_flags_double_managed_skill(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    _seed_lock_entry(home, "w")
+
+    issues = doctor.diagnose()
+    assert any(i.kind == "double-managed" and i.skill == "w" for i in issues)
+
+
+def test_fix_double_managed_removes_lock_entry(home, fake_upstream_repo):
+    import json as _json
+
+    _install(home, fake_upstream_repo)
+    _seed_lock_entry(home, "w")
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "double-managed"]
+    issue.apply()
+
+    lock = _json.loads((home / ".agents" / ".skill-lock.json").read_text())
+    assert "w" not in lock["skills"]
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert any("\tdoctor-fix\t" in line and line.endswith("\tw") for line in history)
+
+
+def test_diagnose_flags_missing_baseline_layer(home, fake_upstream_repo):
+    import shutil as _shutil
+
+    _install(home, fake_upstream_repo)
+    _shutil.rmtree(home / ".agents" / "sync-skills" / "w" / "baseline")
+
+    issues = doctor.diagnose()
+    assert any(i.kind == "missing-layers" and i.skill == "w" for i in issues)
+
+
+def test_fix_missing_layers_refetches_from_upstream(home, fake_upstream_repo):
+    import shutil as _shutil
+
+    _install(home, fake_upstream_repo, content="seeded\n")
+    _shutil.rmtree(home / ".agents" / "sync-skills" / "w" / "baseline")
+    _shutil.rmtree(home / ".agents" / "sync-skills" / "w" / "upstream")
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "missing-layers"]
+    issue.apply()
+
+    base = home / ".agents" / "sync-skills" / "w"
+    assert (base / "baseline" / "SKILL.md").read_text() == "seeded\n"
+    assert (base / "upstream" / "SKILL.md").read_text() == "seeded\n"
+    history = (home / ".agents" / "sync-skills" / "history.log").read_text().splitlines()
+    assert any("\tdoctor-fix\t" in line and line.endswith("\tw") for line in history)
+
+
+def test_fix_missing_active_does_not_clobber_when_other_layers_present(
+    home, fake_upstream_repo
+):
+    import shutil as _shutil
+
+    _install(home, fake_upstream_repo, content="seeded\n")
+    base = home / ".agents" / "sync-skills" / "w"
+    (base / "active" / "SKILL.md").write_text("custom\n")
+    _shutil.rmtree(base / "upstream")
+
+    [issue] = [i for i in doctor.diagnose() if i.kind == "missing-layers"]
+    issue.apply()
+
+    # Existing active/ stays untouched; only the missing layer is restored.
+    assert (base / "active" / "SKILL.md").read_text() == "custom\n"
+    assert (base / "upstream" / "SKILL.md").read_text() == "seeded\n"
+
+
+def test_main_clean_state_prints_clean_bill_and_exits_zero(home, fake_upstream_repo, capsys):
+    _install(home, fake_upstream_repo)
+    rc = doctor.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "clean" in out.lower()
+
+
+def test_main_with_yes_applies_every_fix_and_rerun_is_clean(home, fake_upstream_repo):
+    import shutil as _shutil
+
+    _install(home, fake_upstream_repo)
+    # 1: missing symlink
+    (home / ".claude" / "skills" / "w").unlink()
+    # 4: orphan folder
+    sync = home / ".agents" / "sync-skills"
+    (sync / "stray" / "active").mkdir(parents=True)
+    (sync / "stray" / "active" / "SKILL.md").write_text("v\n")
+    # 5: double-managed
+    _seed_lock_entry(home, "w")
+    # 6: missing layer
+    _shutil.rmtree(sync / "w" / "baseline")
+
+    rc = doctor.main(["--yes"])
+    assert rc == 0
+    assert doctor.diagnose() == []
+
+
+def test_main_without_yes_lists_findings_and_does_not_apply(home, fake_upstream_repo, capsys):
+    _install(home, fake_upstream_repo)
+    (home / ".claude" / "skills" / "w").unlink()
+
+    rc = doctor.main([])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "symlink-missing" in out
+    assert "--yes" in out
+    # Fix not applied: symlink still missing.
+    assert not (home / ".claude" / "skills" / "w").exists()


### PR DESCRIPTION
## Summary
- New `scripts/doctor.py` with `Issue` dataclass + 5 check functions covering all 6 documented diagnoses: `symlink-missing`, `symlink-clobber` (+ `stranded-edit` sub-case), `registry-orphan`, `folder-orphan`, `double-managed`, `missing-layers`.
- Each fix appends a `doctor-fix` audit event. `main()` lists findings; `--yes` applies all.
- `tests/test_doctor.py` — 22 tests, one diagnosis at a time, each verifying detect + fix on synthetic broken state, plus a clean-rerun test that proves convergence.
- `SKILL.md` updated to mention `doctor` in the bundled-scripts paragraph.

Closes #10.

## Test plan
- [x] \`uv run pytest\` — 51/51 pass
- [ ] Manual smoke: \`python3 scripts/doctor.py\` on real \`~/.agents/sync-skills\` reports clean