### PR TITLE
Pre-flight checks for /sync-skills (closes #11)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -21,6 +21,8 @@ python3 ~/.claude/skills/sync-skills/scripts/doctor.py [--yes]
 
 `install` registers a skill, seeds all three trees from upstream, creates the symlink, and appends an audit event. `accept` advances the baseline (`baseline := upstream`) — the primitive behind cherry-pick, wholesale, and skip in `/sync-skills`. `migrate` ports a skill installed via `npx skills` (vercel-labs/skills) into sync-skills: copies `~/.agents/skills/<name>/` into all three trees, swings the symlink, registers it, and removes the entry from `~/.agents/.skill-lock.json`. With no name, migrates every entry in the lock file. `relink` recreates every `~/.claude/skills/<name>` symlink from `sources.json` — the cross-machine restore: drop a saved `~/.agents/sync-skills/` folder onto a fresh machine, run `relink`, all symlinks come back. Idempotent; refuses to overwrite a non-symlink at the target path. `doctor` scans for the six known state-drift failure modes (broken symlink, vercel clobber + stranded edits, registry orphan, folder orphan, double-managed lock entry, missing layer) and prints findings; pass `--yes` to apply every proposed fix. Each applied fix appends a `doctor-fix` audit event.
 
+> **Clobber risk.** `npx skills` rewrites `~/.claude/skills/<name>` to point into `~/.agents/skills/<name>`, silently breaking the symlink into `active/`. The `/sync-skills` pre-flight catches this; `doctor` is the standalone equivalent.
+
 ## Inspecting state
 
 ```bash
@@ -37,6 +39,36 @@ Shorthand for inline calls:
 
 ```bash
 SS='import sys; sys.path.insert(0, "'"$HOME"'/.claude/skills/sync-skills/scripts"); import core'
+```
+
+### 0. Pre-flight (run before fetching)
+
+Surface drift before the user reviews changes against a broken setup.
+
+**a. First-run hint.** If `core.registry_load()` is empty AND `core.migration_candidates()` is empty, print:
+
+> No skills registered yet. Install one with `python3 ~/.claude/skills/sync-skills/scripts/install.py <name> <owner/repo> <path>`.
+
+…and stop.
+
+**b. Migration prompt.** If `core.migration_candidates()` is non-empty, list them and `AskUserQuestion`: `migrate-all` / `migrate-some` / `skip`. On `migrate-all`, run `migrate.py` with no args. On `migrate-some`, ask per-skill, then call `migrate.py <name>` for each chosen.
+
+**c. Clobber check + stranded-edit handling.** For each `name` where `core.is_clobbered(name)` is True:
+
+1. If `core.has_stranded_edit(name)`, `AskUserQuestion`: `import-then-relink` / `relink-only` / `defer`.
+   - `import-then-relink` — `cp ~/.agents/skills/<name>/SKILL.md ~/.agents/sync-skills/<name>/active/SKILL.md`, then re-link.
+   - `relink-only` — re-link, drop the npx-side edit.
+   - `defer` — leave it; this skill is excluded from the rest of this run.
+2. Otherwise `AskUserQuestion`: `relink` / `defer`.
+3. Re-link by running `python3 ~/.claude/skills/sync-skills/scripts/relink.py` once after the loop (idempotent across all skills).
+
+Inline check:
+
+```bash
+python3 -c "$SS
+clobbered = [n for n in core.registry_load() if core.is_clobbered(n)]
+print('\n'.join(clobbered))
+"
 ```
 
 ### 1. Fetch every registered upstream

--- a/scripts/core.py
+++ b/scripts/core.py
@@ -99,6 +99,53 @@ def paths_for(name: str) -> Paths:
     )
 
 
+def _npx_skill_dir(name: str) -> Path:
+    return Path(os.environ["HOME"]) / ".agents" / "skills" / name
+
+
+def is_clobbered(name: str) -> bool:
+    """True if ~/.claude/skills/<name> symlinks into ~/.agents/skills/<name>."""
+    link = paths_for(name).symlink
+    if not link.is_symlink():
+        return False
+    try:
+        return link.resolve() == _npx_skill_dir(name).resolve()
+    except OSError:
+        return False
+
+
+def _lock_path() -> Path:
+    return Path(os.environ["HOME"]) / ".agents" / ".skill-lock.json"
+
+
+def lock_load() -> dict:
+    p = _lock_path()
+    if not p.exists():
+        return {"version": 3, "skills": {}}
+    return json.loads(p.read_text())
+
+
+def migration_candidates() -> list[str]:
+    """Lock-file skills with an active npx-style symlink and no sources.json entry."""
+    registered = set(registry_load().keys())
+    out: list[str] = []
+    for name in lock_load().get("skills", {}):
+        if name in registered:
+            continue
+        if is_clobbered(name):
+            out.append(name)
+    return sorted(out)
+
+
+def has_stranded_edit(name: str) -> bool:
+    """True if ~/.agents/skills/<name>/SKILL.md differs from active/SKILL.md."""
+    npx = _npx_skill_dir(name) / "SKILL.md"
+    active = paths_for(name).active / "SKILL.md"
+    if not (npx.is_file() and active.is_file()):
+        return False
+    return npx.read_bytes() != active.read_bytes()
+
+
 def copy_tree(src: Path, dst: Path) -> None:
     if dst.exists():
         shutil.rmtree(dst)

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -20,19 +20,10 @@ def _npx_dir(name: str) -> Path:
     return Path(os.environ["HOME"]) / ".agents" / "skills" / name
 
 
-def _lock_path() -> Path:
-    return Path(os.environ["HOME"]) / ".agents" / ".skill-lock.json"
-
-
-def _lock_load() -> dict:
-    p = _lock_path()
-    if not p.exists():
-        return {"version": 3, "skills": {}}
-    return json.loads(p.read_text())
-
-
 def _lock_save(data: dict) -> None:
-    _lock_path().write_text(json.dumps(data, indent=2) + "\n")
+    (Path(os.environ["HOME"]) / ".agents" / ".skill-lock.json").write_text(
+        json.dumps(data, indent=2) + "\n"
+    )
 
 
 @dataclass
@@ -65,15 +56,6 @@ def _import_stranded_edit(name: str) -> Callable[[], None]:
     return apply
 
 
-def _points_into_npx(symlink: Path, name: str) -> bool:
-    if not symlink.is_symlink():
-        return False
-    try:
-        return symlink.resolve() == _npx_dir(name).resolve()
-    except OSError:
-        return False
-
-
 def _check_symlinks() -> list[Issue]:
     issues: list[Issue] = []
     for name in core.registry_load():
@@ -85,7 +67,7 @@ def _check_symlinks() -> list[Issue]:
         if paths.symlink.exists() and not paths.symlink.is_symlink():
             continue
 
-        if _points_into_npx(paths.symlink, name):
+        if core.is_clobbered(name):
             issues.append(
                 Issue(
                     kind="symlink-clobber",
@@ -94,13 +76,7 @@ def _check_symlinks() -> list[Issue]:
                     apply=_fix_symlink(name),
                 )
             )
-            npx_skill = _npx_dir(name) / "SKILL.md"
-            active_skill = paths.active / "SKILL.md"
-            if (
-                npx_skill.is_file()
-                and active_skill.is_file()
-                and npx_skill.read_bytes() != active_skill.read_bytes()
-            ):
+            if core.has_stranded_edit(name):
                 issues.append(
                     Issue(
                         kind="stranded-edit",
@@ -178,7 +154,7 @@ def _check_folder_orphans() -> list[Issue]:
 
 def _drop_lock_entry(name: str) -> Callable[[], None]:
     def apply() -> None:
-        lock = _lock_load()
+        lock = core.lock_load()
         if lock.get("skills", {}).pop(name, None) is not None:
             _lock_save(lock)
         core.audit_append("doctor-fix", name)
@@ -188,7 +164,7 @@ def _drop_lock_entry(name: str) -> Callable[[], None]:
 
 def _check_double_managed() -> list[Issue]:
     issues: list[Issue] = []
-    locked = set(_lock_load().get("skills", {}).keys())
+    locked = set(core.lock_load().get("skills", {}).keys())
     for name in core.registry_load():
         if name in locked:
             issues.append(

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -1,0 +1,96 @@
+import json
+
+import core
+import install
+
+
+def _install(home, fake_upstream_repo, name="w", content="v\n"):
+    repo = fake_upstream_repo(f"acme/{name}", f"skills/{name}", {"SKILL.md": content})
+    install.main([name, repo, f"skills/{name}"])
+
+
+def _make_clobber(home, name="w", npx_content="v\n"):
+    npx_dir = home / ".agents" / "skills" / name
+    npx_dir.mkdir(parents=True)
+    (npx_dir / "SKILL.md").write_text(npx_content)
+    link = home / ".claude" / "skills" / name
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    link.symlink_to(npx_dir)
+
+
+def _seed_lock(home, name, source="x/skills"):
+    lock = home / ".agents" / ".skill-lock.json"
+    data = json.loads(lock.read_text()) if lock.exists() else {"version": 3, "skills": {}}
+    data["skills"][name] = {
+        "source": source,
+        "skillPath": f"{name}/SKILL.md",
+        "skillFolderHash": "h",
+    }
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text(json.dumps(data))
+
+
+def test_is_clobbered_true_when_symlink_points_into_npx_dir(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    _make_clobber(home)
+    assert core.is_clobbered("w") is True
+
+
+def test_is_clobbered_false_when_symlink_points_into_active(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    assert core.is_clobbered("w") is False
+
+
+def test_is_clobbered_false_when_symlink_missing(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    (home / ".claude" / "skills" / "w").unlink()
+    assert core.is_clobbered("w") is False
+
+
+def test_has_stranded_edit_true_when_npx_skill_md_diverges(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo, content="v\n")
+    _make_clobber(home, npx_content="HAND-EDITED\n")
+    assert core.has_stranded_edit("w") is True
+
+
+def test_has_stranded_edit_false_when_npx_matches_active(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo, content="v\n")
+    _make_clobber(home, npx_content="v\n")
+    assert core.has_stranded_edit("w") is False
+
+
+def test_has_stranded_edit_false_when_npx_dir_absent(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo)
+    assert core.has_stranded_edit("w") is False
+
+
+def test_migration_candidates_empty_when_lock_file_absent(home):
+    assert core.migration_candidates() == []
+
+
+def test_migration_candidates_lists_locked_skill_with_npx_symlink(home):
+    _seed_lock(home, "foo")
+    _make_clobber(home, name="foo")
+    assert core.migration_candidates() == ["foo"]
+
+
+def test_migration_candidates_skips_already_registered_skills(home, fake_upstream_repo):
+    _install(home, fake_upstream_repo, name="w")
+    _seed_lock(home, "w")
+    # 'w' is double-managed, not a migration candidate (doctor handles that case).
+    assert "w" not in core.migration_candidates()
+
+
+def test_migration_candidates_skips_locked_skill_without_active_npx_symlink(home):
+    _seed_lock(home, "bar")
+    # No symlink at ~/.claude/skills/bar — nothing to migrate.
+    assert core.migration_candidates() == []
+
+
+def test_migration_candidates_returns_sorted_names(home):
+    _seed_lock(home, "zebra")
+    _seed_lock(home, "alpha")
+    _make_clobber(home, name="zebra")
+    _make_clobber(home, name="alpha")
+    assert core.migration_candidates() == ["alpha", "zebra"]


### PR DESCRIPTION
## Summary

- Adds §0 pre-flight to `SKILL.md` ahead of fetch: first-run hint, migration prompt, clobber + stranded-edit handler. Plus a one-line clobber-risk note pointing at `doctor`.
- Promotes three helpers to `core.py` — `is_clobbered`, `has_stranded_edit`, `migration_candidates` (and `lock_load`).
- Refactors `doctor.py` to consume the new helpers (drops `_points_into_npx`, the inline byte comparison, and the duplicate lock loader).

Closes #11. Final v1 backlog item — wraps PRD #1.

## Test plan

- [x] `uv run pytest` — 62 tests green, including 11 new behavioural tests for the helpers in `tests/test_core_helpers.py`.
- [x] Manual smoke against a synthetic clobbered + locked state confirmed the inline `core` calls in SKILL.md return the expected values (`migration_candidates() == ['foo']`, `is_clobbered('foo') is True`, empty registry seen as empty).
- [ ] Dogfood `/sync-skills` end-to-end against `grill-me` (carry-over from #9).