### PR TITLE
Foundation: rename core.py + dispatcher skeleton + audit subcommand (closes #29)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -137,7 +137,7 @@ For each `upstream-changed` skill, in registry order:
 5. Apply each included hunk via `Edit` against `~/.agents/sync-skills/<name>/active/<file>`, passing the hunk's `old_string` / `new_string` verbatim.
 6. Append the audit event and advance the baseline:
    ```bash
-   python3 -c "$SS; core.audit_append('cherry-pick', '<name>')"
+   python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py audit cherry-pick <name>
    python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
    ```
 7. **Conflict path** — if `Edit` fails because `old_string` no longer matches (the user already customised those lines), surface the failing hunk and `AskUserQuestion`:
@@ -159,14 +159,14 @@ python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
 #### skip
 
 ```bash
-python3 -c "$SS; core.audit_append('skip', '<name>')"
+python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py audit skip <name>
 python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
 ```
 
 #### defer
 
 ```bash
-python3 -c "$SS; core.audit_append('defer', '<name>')"
+python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py audit defer <name>
 ```
 
 ### 5. Final summary

--- a/scripts/accept.py
+++ b/scripts/accept.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-import core
+import sync_skills as core
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
-import core
+import sync_skills as core
 
 
 def _npx_dir(name: str) -> Path:

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-import core
+import sync_skills as core
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -12,7 +12,7 @@ import os
 import sys
 from pathlib import Path
 
-import core
+import sync_skills as core
 
 
 def _lock_path() -> Path:

--- a/scripts/relink.py
+++ b/scripts/relink.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-import core
+import sync_skills as core
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -215,3 +215,30 @@ def fetch(repo: str, path: str, ref: str = "HEAD"):
         if not skill_dir.is_dir():
             raise FileNotFoundError(f"path {path!r} not found in {repo}")
         yield skill_dir
+
+
+def _cmd_audit(args: "argparse.Namespace") -> int:
+    audit_append(args.action, args.skill)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="sync_skills.py",
+        description="CLI dispatcher for sync-skills helpers used by /sync-skills SKILL.md.",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_audit = sub.add_parser("audit", help="Append an audit-log line.")
+    p_audit.add_argument("action")
+    p_audit.add_argument("skill")
+    p_audit.set_defaults(func=_cmd_audit)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,4 +1,4 @@
-from core import backup_active, paths_for
+from sync_skills import backup_active, paths_for
 
 
 def test_bak_created_when_absent(home):

--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -1,6 +1,6 @@
 import json
 
-import core
+import sync_skills
 import install
 
 
@@ -34,58 +34,58 @@ def _seed_lock(home, name, source="x/skills"):
 def test_is_clobbered_true_when_symlink_points_into_npx_dir(home, fake_upstream_repo):
     _install(home, fake_upstream_repo)
     _make_clobber(home)
-    assert core.is_clobbered("w") is True
+    assert sync_skills.is_clobbered("w") is True
 
 
 def test_is_clobbered_false_when_symlink_points_into_active(home, fake_upstream_repo):
     _install(home, fake_upstream_repo)
-    assert core.is_clobbered("w") is False
+    assert sync_skills.is_clobbered("w") is False
 
 
 def test_is_clobbered_false_when_symlink_missing(home, fake_upstream_repo):
     _install(home, fake_upstream_repo)
     (home / ".claude" / "skills" / "w").unlink()
-    assert core.is_clobbered("w") is False
+    assert sync_skills.is_clobbered("w") is False
 
 
 def test_has_stranded_edit_true_when_npx_skill_md_diverges(home, fake_upstream_repo):
     _install(home, fake_upstream_repo, content="v\n")
     _make_clobber(home, npx_content="HAND-EDITED\n")
-    assert core.has_stranded_edit("w") is True
+    assert sync_skills.has_stranded_edit("w") is True
 
 
 def test_has_stranded_edit_false_when_npx_matches_active(home, fake_upstream_repo):
     _install(home, fake_upstream_repo, content="v\n")
     _make_clobber(home, npx_content="v\n")
-    assert core.has_stranded_edit("w") is False
+    assert sync_skills.has_stranded_edit("w") is False
 
 
 def test_has_stranded_edit_false_when_npx_dir_absent(home, fake_upstream_repo):
     _install(home, fake_upstream_repo)
-    assert core.has_stranded_edit("w") is False
+    assert sync_skills.has_stranded_edit("w") is False
 
 
 def test_migration_candidates_empty_when_lock_file_absent(home):
-    assert core.migration_candidates() == []
+    assert sync_skills.migration_candidates() == []
 
 
 def test_migration_candidates_lists_locked_skill_with_npx_symlink(home):
     _seed_lock(home, "foo")
     _make_clobber(home, name="foo")
-    assert core.migration_candidates() == ["foo"]
+    assert sync_skills.migration_candidates() == ["foo"]
 
 
 def test_migration_candidates_skips_already_registered_skills(home, fake_upstream_repo):
     _install(home, fake_upstream_repo, name="w")
     _seed_lock(home, "w")
     # 'w' is double-managed, not a migration candidate (doctor handles that case).
-    assert "w" not in core.migration_candidates()
+    assert "w" not in sync_skills.migration_candidates()
 
 
 def test_migration_candidates_skips_locked_skill_without_active_npx_symlink(home):
     _seed_lock(home, "bar")
     # No symlink at ~/.claude/skills/bar — nothing to migrate.
-    assert core.migration_candidates() == []
+    assert sync_skills.migration_candidates() == []
 
 
 def test_migration_candidates_returns_sorted_names(home):
@@ -93,4 +93,4 @@ def test_migration_candidates_returns_sorted_names(home):
     _seed_lock(home, "alpha")
     _make_clobber(home, name="zebra")
     _make_clobber(home, name="alpha")
-    assert core.migration_candidates() == ["alpha", "zebra"]
+    assert sync_skills.migration_candidates() == ["alpha", "zebra"]

--- a/tests/test_diff_parser.py
+++ b/tests/test_diff_parser.py
@@ -1,4 +1,4 @@
-from core import parse_hunks
+from sync_skills import parse_hunks
 
 
 def test_single_hunk_diff():

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "sync_skills.py"
+
+
+def test_audit_subcommand_appends_history_log(home):
+    rc = subprocess.run(
+        [sys.executable, str(SCRIPT), "audit", "cherry-pick", "widget"],
+        check=False,
+    ).returncode
+    assert rc == 0
+
+    log = home / ".agents" / "sync-skills" / "history.log"
+    line = log.read_text().strip().splitlines()[-1]
+    ts, action, skill = line.split("\t")
+    assert action == "cherry-pick"
+    assert skill == "widget"
+
+
+def test_help_lists_audit_subcommand():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "audit" in result.stdout


### PR DESCRIPTION
## Summary

First slice of the CLI dispatcher (parent #28). Lays groundwork for replacing the inline `python3 -c "$SS ..."` blocks that break Claude Code's permission renderer.

- Rename `scripts/core.py` → `scripts/sync_skills.py`.
- Standalone scripts: `import core` → `import sync_skills as core` (call sites unchanged).
- Tests: `import core` → `import sync_skills` (call sites updated).
- Argparse dispatcher at the bottom of `sync_skills.py` exposes one subcommand: `audit <action> <skill>`.
- `tests/test_dispatcher.py`: subprocess smoke tests for `audit` (writes `history.log`) and `--help` (lists `audit`).
- `SKILL.md` cherry-pick / skip / defer paths invoke the dispatcher. `$SS` shorthand stays — still used by the 5 remaining inline blocks.

Closes #29.

## Test plan

- [x] `uv run pytest` — 64/64 pass (62 pre-existing + 2 new).
- [x] `python3 scripts/sync_skills.py --help` lists `audit`.
- [x] `python3 scripts/sync_skills.py audit cherry-pick foo` exits 0 and appends a tab-separated line to `~/.agents/sync-skills/history.log`.