### PR TITLE
Pre-flight subcommands: registry-list, migration-candidates, clobbered-list, stranded-edit

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -45,31 +45,28 @@ SS='import sys; sys.path.insert(0, "'"$HOME"'/.claude/skills/sync-skills/scripts
 
 Surface drift before the user reviews changes against a broken setup.
 
-**a. First-run hint.** If `core.registry_load()` is empty AND `core.migration_candidates()` is empty, print:
+**a. First-run hint.** If both `python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py registry-list` returns `{}` AND `python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py migration-candidates` is empty, print:
 
 > No skills registered yet. Install one with `python3 ~/.claude/skills/sync-skills/scripts/install.py <name> <owner/repo> <path>`.
 
 …and stop.
 
-**b. Migration prompt.** If `core.migration_candidates()` is non-empty, list them and `AskUserQuestion`: `migrate-all` / `migrate-some` / `skip`. On `migrate-all`, run `migrate.py` with no args. On `migrate-some`, ask per-skill, then call `migrate.py <name>` for each chosen.
+**b. Migration prompt.** If `python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py migration-candidates` is non-empty, list them and `AskUserQuestion`: `migrate-all` / `migrate-some` / `skip`. On `migrate-all`, run `migrate.py` with no args. On `migrate-some`, ask per-skill, then call `migrate.py <name>` for each chosen.
 
-**c. Clobber check + stranded-edit handling.** For each `name` where `core.is_clobbered(name)` is True:
+**c. Clobber check + stranded-edit handling.** Get the list of clobbered registered skills:
 
-1. If `core.has_stranded_edit(name)`, `AskUserQuestion`: `import-then-relink` / `relink-only` / `defer`.
+```bash
+python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py clobbered-list
+```
+
+For each `name` in that list:
+
+1. If `python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py stranded-edit <name>` exits 0, `AskUserQuestion`: `import-then-relink` / `relink-only` / `defer`.
    - `import-then-relink` — `cp ~/.agents/skills/<name>/SKILL.md ~/.agents/sync-skills/<name>/active/SKILL.md`, then re-link.
    - `relink-only` — re-link, drop the npx-side edit.
    - `defer` — leave it; this skill is excluded from the rest of this run.
 2. Otherwise `AskUserQuestion`: `relink` / `defer`.
 3. Re-link by running `python3 ~/.claude/skills/sync-skills/scripts/relink.py` once after the loop (idempotent across all skills).
-
-Inline check:
-
-```bash
-python3 -c "$SS
-clobbered = [n for n in core.registry_load() if core.is_clobbered(n)]
-print('\n'.join(clobbered))
-"
-```
 
 ### 1. Fetch every registered upstream
 

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -222,6 +222,28 @@ def _cmd_audit(args: "argparse.Namespace") -> int:
     return 0
 
 
+def _cmd_registry_list(args: "argparse.Namespace") -> int:
+    print(json.dumps(registry_load()))
+    return 0
+
+
+def _cmd_migration_candidates(args: "argparse.Namespace") -> int:
+    for name in migration_candidates():
+        print(name)
+    return 0
+
+
+def _cmd_clobbered_list(args: "argparse.Namespace") -> int:
+    for name in sorted(registry_load()):
+        if is_clobbered(name):
+            print(name)
+    return 0
+
+
+def _cmd_stranded_edit(args: "argparse.Namespace") -> int:
+    return 0 if has_stranded_edit(args.name) else 1
+
+
 def main(argv: list[str] | None = None) -> int:
     import argparse
 
@@ -235,6 +257,28 @@ def main(argv: list[str] | None = None) -> int:
     p_audit.add_argument("action")
     p_audit.add_argument("skill")
     p_audit.set_defaults(func=_cmd_audit)
+
+    p_registry_list = sub.add_parser("registry-list", help="Emit the registry as JSON.")
+    p_registry_list.set_defaults(func=_cmd_registry_list)
+
+    p_migration = sub.add_parser(
+        "migration-candidates",
+        help="Emit names of npx-managed skills not yet in the registry.",
+    )
+    p_migration.set_defaults(func=_cmd_migration_candidates)
+
+    p_clobbered = sub.add_parser(
+        "clobbered-list",
+        help="Emit names of registered skills whose Claude symlink has been clobbered.",
+    )
+    p_clobbered.set_defaults(func=_cmd_clobbered_list)
+
+    p_stranded = sub.add_parser(
+        "stranded-edit",
+        help="Exit 0 if npx-side SKILL.md differs from active/SKILL.md, 1 otherwise.",
+    )
+    p_stranded.add_argument("name")
+    p_stranded.set_defaults(func=_cmd_stranded_edit)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -5,12 +6,133 @@ from pathlib import Path
 SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "sync_skills.py"
 
 
-def test_audit_subcommand_appends_history_log(home):
-    rc = subprocess.run(
-        [sys.executable, str(SCRIPT), "audit", "cherry-pick", "widget"],
+def _run(*args, **kwargs):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
         check=False,
-    ).returncode
-    assert rc == 0
+        capture_output=True,
+        text=True,
+        **kwargs,
+    )
+
+
+def test_registry_list_emits_empty_object_when_no_registry(home):
+    result = _run("registry-list")
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {}
+
+
+def test_registry_list_emits_registry_contents(home):
+    registry = home / ".agents" / "sync-skills" / "sources.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps({"widget": {"repo": "acme/skills", "path": "widget", "ref": "HEAD"}})
+    )
+
+    result = _run("registry-list")
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {
+        "widget": {"repo": "acme/skills", "path": "widget", "ref": "HEAD"}
+    }
+
+
+def _seed_lock(home, name):
+    lock = home / ".agents" / ".skill-lock.json"
+    data = json.loads(lock.read_text()) if lock.exists() else {"version": 3, "skills": {}}
+    data["skills"][name] = {
+        "source": "x/skills",
+        "skillPath": f"{name}/SKILL.md",
+        "skillFolderHash": "h",
+    }
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    lock.write_text(json.dumps(data))
+
+
+def _make_clobber(home, name):
+    npx_dir = home / ".agents" / "skills" / name
+    npx_dir.mkdir(parents=True)
+    (npx_dir / "SKILL.md").write_text("v\n")
+    link = home / ".claude" / "skills" / name
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    link.symlink_to(npx_dir)
+
+
+def test_migration_candidates_lists_sorted_clobbered_locked_names(home):
+    _seed_lock(home, "zebra")
+    _seed_lock(home, "alpha")
+    _make_clobber(home, "zebra")
+    _make_clobber(home, "alpha")
+
+    result = _run("migration-candidates")
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["alpha", "zebra"]
+
+
+def test_migration_candidates_emits_nothing_when_none(home):
+    result = _run("migration-candidates")
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def _seed_registry(home, name):
+    registry = home / ".agents" / "sync-skills" / "sources.json"
+    data = json.loads(registry.read_text()) if registry.exists() else {}
+    data[name] = {"repo": "acme/skills", "path": name, "ref": "HEAD"}
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(json.dumps(data))
+
+
+def test_clobbered_list_emits_only_registered_clobbered_names(home):
+    _seed_registry(home, "alpha")
+    _seed_registry(home, "beta")
+    _make_clobber(home, "alpha")
+    # beta is registered but not clobbered → excluded.
+    # gamma is clobbered but unregistered → also excluded.
+    _make_clobber(home, "gamma")
+
+    result = _run("clobbered-list")
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["alpha"]
+
+
+def test_clobbered_list_emits_nothing_when_no_registry(home):
+    result = _run("clobbered-list")
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def _seed_active_skill_md(home, name, content):
+    active = home / ".agents" / "sync-skills" / name / "active"
+    active.mkdir(parents=True, exist_ok=True)
+    (active / "SKILL.md").write_text(content)
+
+
+def _seed_npx_skill_md(home, name, content):
+    npx = home / ".agents" / "skills" / name
+    npx.mkdir(parents=True, exist_ok=True)
+    (npx / "SKILL.md").write_text(content)
+
+
+def test_stranded_edit_exits_zero_when_npx_diverges_from_active(home):
+    _seed_active_skill_md(home, "alpha", "v1\n")
+    _seed_npx_skill_md(home, "alpha", "HAND-EDITED\n")
+
+    result = _run("stranded-edit", "alpha")
+    assert result.returncode == 0
+
+
+def test_stranded_edit_exits_one_when_npx_matches_active(home):
+    _seed_active_skill_md(home, "alpha", "v1\n")
+    _seed_npx_skill_md(home, "alpha", "v1\n")
+
+    result = _run("stranded-edit", "alpha")
+    assert result.returncode == 1
+
+
+def test_audit_subcommand_appends_history_log(home):
+    result = _run("audit", "cherry-pick", "widget")
+    assert result.returncode == 0
 
     log = home / ".agents" / "sync-skills" / "history.log"
     line = log.read_text().strip().splitlines()[-1]
@@ -20,11 +142,6 @@ def test_audit_subcommand_appends_history_log(home):
 
 
 def test_help_lists_audit_subcommand():
-    result = subprocess.run(
-        [sys.executable, str(SCRIPT), "--help"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run("--help")
     assert result.returncode == 0
     assert "audit" in result.stdout


### PR DESCRIPTION
## Summary

- Adds four pre-flight dispatcher subcommands to `scripts/sync_skills.py`: `registry-list` (JSON), `migration-candidates`, `clobbered-list`, `stranded-edit <name>` (exit 0 if differs).
- Replaces the inline `python3 -c "\$SS ..."` block in SKILL.md's pre-flight clobber check with a single-line dispatcher call; rewrites 0a/0b/0c prose to reference the new subcommands.
- Smoke test per subcommand in `tests/test_dispatcher.py` (subprocess invocation against fixture state under temp HOME).

Closes #30. Parent: #28.

The fetch / changed-list / cherry-pick / wholesale `python3 -c` blocks still rely on `\$SS` and migrate in follow-up issues.

## Test plan

- [x] `uv run pytest` (72 passed)
- [ ] Manual `/sync-skills` pre-flight against a populated registry — confirm every Bash permission prompt renders cleanly (no "Unhandled node type: string")