### PR TITLE
Fetch + cherry-pick subcommands: fetch-all, changed-list, parse-hunks, backup-active (closes #31)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -33,12 +33,12 @@ tail ~/.agents/sync-skills/history.log                    # audit
 
 ## /sync-skills
 
-The interactive review flow. When the user invokes `/sync-skills`, walk these steps in order. Throughout, prefer the bundled `core` helpers via `python3 -c` over hand-rolled `git`/`diff` so behaviour matches what the scripts do.
+The interactive review flow. When the user invokes `/sync-skills`, walk these steps in order. Throughout, prefer the bundled `sync_skills.py` dispatcher subcommands over hand-rolled `git`/`diff` so behaviour matches what the scripts do.
 
-Shorthand for inline calls:
+Shorthand for the one remaining inline-Python call site (wholesale):
 
 ```bash
-SS='import sys; sys.path.insert(0, "'"$HOME"'/.claude/skills/sync-skills/scripts"); import core'
+SS='import sys; sys.path.insert(0, "'"$HOME"'/.claude/skills/sync-skills/scripts"); import sync_skills as core'
 ```
 
 ### 0. Pre-flight (run before fetching)
@@ -73,13 +73,7 @@ For each `name` in that list:
 For each entry in `sources.json`, clone its `repo` at `ref` and refresh `<sync_root>/<name>/upstream/`:
 
 ```bash
-python3 -c "$SS
-for name, src in core.registry_load().items():
-    p = core.paths_for(name)
-    with core.fetch(src['repo'], src['path'], src['ref']) as u:
-        core.copy_tree(u, p.upstream)
-    print(name)
-"
+python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py fetch-all
 ```
 
 ### 2. Identify `upstream-changed` skills
@@ -87,16 +81,7 @@ for name, src in core.registry_load().items():
 A skill is `upstream-changed` when `baseline/` and `upstream/` differ:
 
 ```bash
-python3 -c "$SS
-import filecmp
-def differs(a, b):
-    c = filecmp.dircmp(str(a), str(b))
-    if c.left_only or c.right_only or c.diff_files: return True
-    return any(differs(a/d, b/d) for d in c.common_dirs)
-for name in core.registry_load():
-    p = core.paths_for(name)
-    if differs(p.baseline, p.upstream): print(name)
-"
+python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py changed-list
 ```
 
 ### 3. If nothing changed
@@ -120,24 +105,24 @@ For each `upstream-changed` skill, in registry order:
 
 #### cherry-pick
 
-1. Capture the diff:
+1. Capture the diff and parse it into hunks in one shot:
    ```bash
-   diff -ur ~/.agents/sync-skills/<name>/baseline ~/.agents/sync-skills/<name>/upstream
+   diff -ur ~/.agents/sync-skills/<name>/baseline ~/.agents/sync-skills/<name>/upstream | python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py parse-hunks
    ```
-2. Parse with `core.parse_hunks(diff_text)` → `list[Hunk(file, old_string, new_string)]`. `file` is the path relative to the skill root.
-3. For each hunk, `AskUserQuestion`: `include` / `exclude`. Show a short preview of `old_string` → `new_string`.
-4. Before the first `Edit` in this round, snapshot `active/SKILL.md`:
+   Output is a JSON list of `{file, old_string, new_string}` objects. `file` is the path relative to the skill root.
+2. For each hunk, `AskUserQuestion`: `include` / `exclude`. Show a short preview of `old_string` → `new_string`.
+3. Before the first `Edit` in this round, snapshot `active/SKILL.md`:
    ```bash
-   python3 -c "$SS; core.backup_active('<name>')"
+   python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py backup-active <name>
    ```
    (One backup per skill per round is enough; the helper overwrites any prior `.bak`.)
-5. Apply each included hunk via `Edit` against `~/.agents/sync-skills/<name>/active/<file>`, passing the hunk's `old_string` / `new_string` verbatim.
-6. Append the audit event and advance the baseline:
+4. Apply each included hunk via `Edit` against `~/.agents/sync-skills/<name>/active/<file>`, passing the hunk's `old_string` / `new_string` verbatim.
+5. Append the audit event and advance the baseline:
    ```bash
    python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py audit cherry-pick <name>
    python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
    ```
-7. **Conflict path** — if `Edit` fails because `old_string` no longer matches (the user already customised those lines), surface the failing hunk and `AskUserQuestion`:
+6. **Conflict path** — if `Edit` fails because `old_string` no longer matches (the user already customised those lines), surface the failing hunk and `AskUserQuestion`:
    - `edit-manually` — print the hunk and the absolute file path, pause until the user says they merged it.
    - `skip-hunk` — drop just this hunk, continue with the rest.
    - `wholesale-this-skill` — abandon cherry-pick, fall through to the wholesale path below.

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -152,6 +152,15 @@ def copy_tree(src: Path, dst: Path) -> None:
     shutil.copytree(src, dst)
 
 
+def tree_differs(a: Path, b: Path) -> bool:
+    import filecmp
+
+    c = filecmp.dircmp(str(a), str(b))
+    if c.left_only or c.right_only or c.diff_files:
+        return True
+    return any(tree_differs(a / d, b / d) for d in c.common_dirs)
+
+
 def backup_active(name: str) -> Path:
     src = paths_for(name).active / "SKILL.md"
     dst = src.with_name("SKILL.md.bak")
@@ -244,6 +253,36 @@ def _cmd_stranded_edit(args: "argparse.Namespace") -> int:
     return 0 if has_stranded_edit(args.name) else 1
 
 
+def _cmd_backup_active(args: "argparse.Namespace") -> int:
+    print(backup_active(args.name))
+    return 0
+
+
+def _cmd_parse_hunks(args: "argparse.Namespace") -> int:
+    import sys
+
+    hunks = parse_hunks(sys.stdin.read())
+    print(json.dumps([h.__dict__ for h in hunks]))
+    return 0
+
+
+def _cmd_changed_list(args: "argparse.Namespace") -> int:
+    for name in registry_load():
+        p = paths_for(name)
+        if tree_differs(p.baseline, p.upstream):
+            print(name)
+    return 0
+
+
+def _cmd_fetch_all(args: "argparse.Namespace") -> int:
+    for name, src in registry_load().items():
+        p = paths_for(name)
+        with fetch(src["repo"], src["path"], src["ref"]) as u:
+            copy_tree(u, p.upstream)
+        print(name)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     import argparse
 
@@ -279,6 +318,31 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_stranded.add_argument("name")
     p_stranded.set_defaults(func=_cmd_stranded_edit)
+
+    p_backup = sub.add_parser(
+        "backup-active",
+        help="Snapshot active/SKILL.md to SKILL.md.bak; print backup path.",
+    )
+    p_backup.add_argument("name")
+    p_backup.set_defaults(func=_cmd_backup_active)
+
+    p_parse = sub.add_parser(
+        "parse-hunks",
+        help="Read a unified diff on stdin; emit JSON list of {file, old_string, new_string}.",
+    )
+    p_parse.set_defaults(func=_cmd_parse_hunks)
+
+    p_changed = sub.add_parser(
+        "changed-list",
+        help="Emit names of registered skills whose baseline/ differs from upstream/.",
+    )
+    p_changed.set_defaults(func=_cmd_changed_list)
+
+    p_fetch = sub.add_parser(
+        "fetch-all",
+        help="Clone each registered upstream and refresh upstream/; emit one line per skill.",
+    )
+    p_fetch.set_defaults(func=_cmd_fetch_all)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -145,3 +145,79 @@ def test_help_lists_audit_subcommand():
     result = _run("--help")
     assert result.returncode == 0
     assert "audit" in result.stdout
+
+
+def test_fetch_all_refreshes_upstream_tree_and_emits_names(home, fake_upstream_repo):
+    repo = fake_upstream_repo("acme/skills", "skills/widget", {"SKILL.md": "v2\n"})
+    registry = home / ".agents" / "sync-skills" / "sources.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps({"widget": {"repo": repo, "path": "skills/widget", "ref": "HEAD"}})
+    )
+    upstream = home / ".agents" / "sync-skills" / "widget" / "upstream"
+    upstream.mkdir(parents=True)
+    (upstream / "STALE.md").write_text("stale\n")
+
+    result = _run("fetch-all")
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["widget"]
+    assert (upstream / "SKILL.md").read_text() == "v2\n"
+    assert not (upstream / "STALE.md").exists()
+
+
+def _seed_layered_skill(home, name, baseline_content, upstream_content):
+    base = home / ".agents" / "sync-skills" / name
+    (base / "baseline").mkdir(parents=True)
+    (base / "upstream").mkdir(parents=True)
+    (base / "baseline" / "SKILL.md").write_text(baseline_content)
+    (base / "upstream" / "SKILL.md").write_text(upstream_content)
+
+
+def test_changed_list_emits_only_skills_whose_baseline_differs_from_upstream(home):
+    _seed_registry(home, "alpha")
+    _seed_registry(home, "beta")
+    _seed_layered_skill(home, "alpha", "v1\n", "v2\n")
+    _seed_layered_skill(home, "beta", "v1\n", "v1\n")
+
+    result = _run("changed-list")
+    assert result.returncode == 0
+    assert result.stdout.splitlines() == ["alpha"]
+
+
+def test_changed_list_emits_nothing_when_no_registry(home):
+    result = _run("changed-list")
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_parse_hunks_emits_json_list_from_stdin_diff():
+    diff = (
+        "--- a/SKILL.md\n"
+        "+++ b/SKILL.md\n"
+        "@@ -1,3 +1,3 @@\n"
+        " line one\n"
+        "-old middle\n"
+        "+new middle\n"
+        " line three\n"
+    )
+    result = _run("parse-hunks", input=diff)
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == [
+        {
+            "file": "SKILL.md",
+            "old_string": "line one\nold middle\nline three\n",
+            "new_string": "line one\nnew middle\nline three\n",
+        }
+    ]
+
+
+def test_backup_active_creates_bak_and_prints_path(home):
+    _seed_active_skill_md(home, "widget", "v1\n")
+
+    result = _run("backup-active", "widget")
+    assert result.returncode == 0
+
+    bak = home / ".agents" / "sync-skills" / "widget" / "active" / "SKILL.md.bak"
+    assert bak.is_file()
+    assert bak.read_text() == "v1\n"
+    assert result.stdout.strip() == str(bak)


### PR DESCRIPTION
## Summary

- Adds four dispatcher subcommands (`fetch-all`, `changed-list`, `parse-hunks`, `backup-active`) and migrates `SKILL.md`'s fetch loop + cherry-pick path off inline `$SS` Python onto single-line dispatcher invocations.
- Fetch loop and cherry-pick block now contain zero `python3 -c`. Only the wholesale path retains `$SS`, removed in #32.
- Side-fix: `$SS` shorthand still said `import core` (broken since the slice-1 rename in #29). Updated to `import sync_skills as core`.

Closes #31. Slice 3 of PRD #28.

## Test plan

- [x] `uv run pytest` — 77 tests pass (5 new dispatcher smoke tests for the four subcommands).
- [ ] Manual `/sync-skills` end-to-end run against a populated registry — confirm fetch + cherry-pick prompts render cleanly (no "Unhandled node type: string").