### PR TITLE
Wholesale subcommand + drop $SS shorthand + allowlist note (closes #32)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -23,6 +23,10 @@ python3 ~/.claude/skills/sync-skills/scripts/doctor.py [--yes]
 
 > **Clobber risk.** `npx skills` rewrites `~/.claude/skills/<name>` to point into `~/.agents/skills/<name>`, silently breaking the symlink into `active/`. The `/sync-skills` pre-flight catches this; `doctor` is the standalone equivalent.
 
+`sync_skills.py` (sibling to the five standalone scripts) is the inline-helper dispatcher used by `/sync-skills`; its subcommands stand in for what would otherwise be inline-Python blocks in this file.
+
+> **Allowlist.** A single entry — `Bash(python3 ~/.claude/skills/sync-skills/scripts/*.py *)` — covers the dispatcher and all five standalone scripts, silencing future `/sync-skills` permission prompts.
+
 ## Inspecting state
 
 ```bash
@@ -34,12 +38,6 @@ tail ~/.agents/sync-skills/history.log                    # audit
 ## /sync-skills
 
 The interactive review flow. When the user invokes `/sync-skills`, walk these steps in order. Throughout, prefer the bundled `sync_skills.py` dispatcher subcommands over hand-rolled `git`/`diff` so behaviour matches what the scripts do.
-
-Shorthand for the one remaining inline-Python call site (wholesale):
-
-```bash
-SS='import sys; sys.path.insert(0, "'"$HOME"'/.claude/skills/sync-skills/scripts"); import sync_skills as core'
-```
 
 ### 0. Pre-flight (run before fetching)
 
@@ -130,11 +128,7 @@ For each `upstream-changed` skill, in registry order:
 #### wholesale
 
 ```bash
-python3 -c "$SS
-p = core.paths_for('<name>')
-core.copy_tree(p.upstream, p.active)
-core.audit_append('wholesale', '<name>')
-"
+python3 ~/.claude/skills/sync-skills/scripts/sync_skills.py wholesale <name>
 python3 ~/.claude/skills/sync-skills/scripts/accept.py <name>
 ```
 

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -283,6 +283,13 @@ def _cmd_fetch_all(args: "argparse.Namespace") -> int:
     return 0
 
 
+def _cmd_wholesale(args: "argparse.Namespace") -> int:
+    p = paths_for(args.name)
+    copy_tree(p.upstream, p.active)
+    audit_append("wholesale", args.name)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     import argparse
 
@@ -343,6 +350,13 @@ def main(argv: list[str] | None = None) -> int:
         help="Clone each registered upstream and refresh upstream/; emit one line per skill.",
     )
     p_fetch.set_defaults(func=_cmd_fetch_all)
+
+    p_wholesale = sub.add_parser(
+        "wholesale",
+        help="Replace active/ with upstream/ and append a wholesale audit event.",
+    )
+    p_wholesale.add_argument("name")
+    p_wholesale.set_defaults(func=_cmd_wholesale)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -221,3 +221,26 @@ def test_backup_active_creates_bak_and_prints_path(home):
     assert bak.is_file()
     assert bak.read_text() == "v1\n"
     assert result.stdout.strip() == str(bak)
+
+
+def test_wholesale_replaces_active_with_upstream_and_audits(home):
+    base = home / ".agents" / "sync-skills" / "widget"
+    (base / "active").mkdir(parents=True)
+    (base / "upstream").mkdir(parents=True)
+    (base / "active" / "SKILL.md").write_text("old\n")
+    (base / "active" / "stale.md").write_text("gone\n")
+    (base / "upstream" / "SKILL.md").write_text("new\n")
+    (base / "upstream" / "fresh.md").write_text("added\n")
+
+    result = _run("wholesale", "widget")
+    assert result.returncode == 0
+
+    assert (base / "active" / "SKILL.md").read_text() == "new\n"
+    assert (base / "active" / "fresh.md").read_text() == "added\n"
+    assert not (base / "active" / "stale.md").exists()
+
+    log = home / ".agents" / "sync-skills" / "history.log"
+    line = log.read_text().strip().splitlines()[-1]
+    _, action, skill = line.split("\t")
+    assert action == "wholesale"
+    assert skill == "widget"


### PR DESCRIPTION
## Summary

- Adds `wholesale <name>` to the `sync_skills.py` dispatcher: replaces `active/` with `upstream/` and appends a `wholesale` audit event in one call.
- Replaces the last inline-Python block in `SKILL.md` (the wholesale path) with a single-line dispatcher invocation; deletes the `$SS` shorthand and its lead-in.
- Documents the recommended allowlist entry — `Bash(python3 ~/.claude/skills/sync-skills/scripts/*.py *)` — and notes that `sync_skills.py` is the inline-helper dispatcher sibling to the five standalone scripts.

Final slice of #28. Verifies PRD AC #3 (zero `$SS`, zero `python3 -c` in `SKILL.md`).

## Test plan

- [x] `uv run pytest` — 78 passed
- [x] New smoke test `test_wholesale_replaces_active_with_upstream_and_audits` covers tree-replace + audit append
- [x] `grep -E '\$SS|python3 -c' SKILL.md` returns nothing
- [ ] Manual `/sync-skills` end-to-end with the suggested allowlist entry → no permission prompts (PRD AC #6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)