### PR TITLE
Fix fetch() with commit SHAs + stop migrate from pinning to tree hash

### DIFF
--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -63,8 +63,9 @@ def _migrate_one(name: str, entry: dict) -> None:
 
     repo = entry["source"]
     path = _path_from_skillpath(entry["skillPath"])
-    ref = entry.get("skillFolderHash", "HEAD")
-    core.registry_set(name, repo, path, ref)
+    # skillFolderHash is a content fingerprint (tree hash), not a fetchable
+    # git commit; pin to HEAD so fetch-all keeps working post-migrate.
+    core.registry_set(name, repo, path, "HEAD")
     core.audit_append("migrate", name)
     _drop_lock_entry(name)
 

--- a/scripts/sync_skills.py
+++ b/scripts/sync_skills.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -209,17 +210,30 @@ def _resolve_url(repo: str) -> str:
     return f"https://github.com/{repo}.git"
 
 
+_SHA_RE = re.compile(r"[0-9a-f]{7,40}")
+
+
 @contextmanager
 def fetch(repo: str, path: str, ref: str = "HEAD"):
     """Clone repo at ref into a tempdir; yield the path to `path` inside it."""
     url = _resolve_url(repo)
     with tempfile.TemporaryDirectory() as tmp:
         clone_dir = Path(tmp) / "clone"
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref and ref != "HEAD":
-            cmd += ["--branch", ref]
-        cmd += [url, str(clone_dir)]
-        subprocess.run(cmd, check=True, capture_output=True)
+        if ref and ref != "HEAD" and _SHA_RE.fullmatch(ref):
+            # `git clone --branch` only accepts named refs; for commit SHAs,
+            # init + fetch the SHA directly + checkout FETCH_HEAD.
+            clone_dir.mkdir()
+            run = lambda *a: subprocess.run(a, cwd=clone_dir, check=True, capture_output=True)
+            run("git", "init", "-q")
+            run("git", "remote", "add", "origin", url)
+            run("git", "fetch", "--depth", "1", "origin", ref)
+            run("git", "checkout", "-q", "FETCH_HEAD")
+        else:
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref and ref != "HEAD":
+                cmd += ["--branch", ref]
+            cmd += [url, str(clone_dir)]
+            subprocess.run(cmd, check=True, capture_output=True)
         skill_dir = clone_dir / path if path and path != "." else clone_dir
         if not skill_dir.is_dir():
             raise FileNotFoundError(f"path {path!r} not found in {repo}")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -48,6 +48,28 @@ def test_install_with_explicit_ref(home, fake_upstream_repo):
         assert (base / layer / "SKILL.md").read_text() == "v2\n"
 
 
+def test_install_with_sha_ref(home, fake_upstream_repo):
+    repo_url = fake_upstream_repo("acme/widget", "skills/widget", {"SKILL.md": "v1\n"})
+    repo_dir = Path(repo_url.removeprefix("file://"))
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (repo_dir / "skills" / "widget" / "SKILL.md").write_text("v2\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "v2"], cwd=repo_dir, check=True)
+
+    rc = install.main(["widget", repo_url, "skills/widget", sha])
+    assert rc == 0
+
+    base = home / ".agents" / "sync-skills" / "widget"
+    for layer in ("active", "baseline", "upstream"):
+        assert (base / layer / "SKILL.md").read_text() == "v1\n"
+
+
 def test_install_refuses_existing_name(home, fake_upstream_repo, capsys):
     repo_url = fake_upstream_repo("acme/w", "skills/w", {"SKILL.md": "x"})
     install.main(["w", repo_url, "skills/w"])

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -50,7 +50,7 @@ def test_migrate_named_skill_populates_three_trees_and_symlink_and_registry(home
 
     registry = json.loads((home / ".agents" / "sync-skills" / "sources.json").read_text())
     assert registry == {
-        "widget": {"repo": "acme/skills", "path": "skills/widget", "ref": "abc123"}
+        "widget": {"repo": "acme/skills", "path": "skills/widget", "ref": "HEAD"}
     }
 
     lock = json.loads((home / ".agents" / ".skill-lock.json").read_text())
@@ -71,7 +71,7 @@ def test_migrate_derives_path_for_flat_layout(home):
     assert registry["tdd"] == {
         "repo": "mattpocock/skills",
         "path": "tdd",
-        "ref": "deadbeef",
+        "ref": "HEAD",
     }
 
 


### PR DESCRIPTION
## Summary
- \`fetch()\` now handles SHA-shaped refs via \`git init\` + \`git fetch <sha>\` + \`git checkout FETCH_HEAD\` (closes #40 — \`git clone --branch\` only accepts named refs).
- \`migrate.py\` no longer copies \`skillFolderHash\` (a tree hash, not a commit) into the registry as \`ref\`; pins to \`HEAD\` instead, so migrated skills stay refreshable.

Hit while dogfooding: migrating \`grill-me\` recorded the npx tree hash as \`ref\`, then \`fetch-all\` blew up on \`git clone --branch <tree-sha>\`. Note: a separate failure (upstream skill moved to \`skills/productivity/grill-me\`) is tracked by #33 and not addressed here.

## Test plan
- [x] New failing test \`test_install_with_sha_ref\` reproduces the clone failure on a SHA-pinned ref; passes after the fetch() fix.
- [x] Existing \`test_migrate_*\` tests updated to assert \`ref == "HEAD"\` after migrate.
- [x] Full suite: 79 passed.
- [ ] Manual: \`fetch-all\` against a registry with a real commit-SHA pin (vs. tree-SHA / branch / HEAD).